### PR TITLE
updated inference page

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ stop-port-forward:
 
 .PHONY: deploy-core
 deploy-core:
+	kubectl config use-context kind-kind
 	kubectl apply -f k8s/secrets.yaml
 	kubectl apply -f k8s/redis/redis-deployment.yaml
 	kubectl apply -f k8s/redis/redis-service.yaml

--- a/src/fast_api_app/routes/infer.py
+++ b/src/fast_api_app/routes/infer.py
@@ -33,41 +33,105 @@ persistent_client = httpx.AsyncClient()
 
 @router.get("/api/infer", response_class=HTMLResponse)
 async def infer_instructions():
-    return HTMLResponse(content="""
+    return HTMLResponse(
+        content="""
 <!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Inference API Instructions</title>
+    <title>SplatGPT Inference API Instructions</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+            line-height: 1.6;
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 2rem;
+            color: #333;
+        }
+        
+        h1, h2, h3 {
+            color: #2c3e50;
+            margin-top: 2rem;
+        }
+        
+        h1 {
+            border-bottom: 2px solid #eee;
+            padding-bottom: 0.5rem;
+        }
+        
+        pre {
+            background-color: #f6f8fa;
+            padding: 1rem;
+            border-radius: 6px;
+            overflow-x: auto;
+        }
+        
+        code {
+            background-color: #f6f8fa;
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            font-family: 'Monaco', 'Consolas', monospace;
+        }
+        
+        ul, ol {
+            padding-left: 2rem;
+        }
+        
+        li {
+            margin: 0.5rem 0;
+        }
+        
+        .endpoint {
+            background-color: #e8f4f8;
+            padding: 1rem;
+            border-radius: 6px;
+            margin: 1rem 0;
+        }
+        
+        .note {
+            background-color: #fff3cd;
+            border-left: 4px solid #ffc107;
+            padding: 1rem;
+            margin: 1rem 0;
+        }
+        
+        .special-token {
+            font-family: monospace;
+            color: #6c757d;
+        }
+    </style>
 </head>
 <body>
-    <h1>Inference API Instructions</h1>
+    <h1>SplatGPT Inference API Instructions</h1>
     
     <p>This endpoint provides detailed instructions on how to use the inference API for Splatoon 3 gear ability predictions.</p>
     
-    <h2>Endpoint Details</h2>
-    <ul>
-        <li><strong>Method:</strong> POST</li>
-        <li><strong>Endpoint:</strong> /api/infer</li>
-    </ul>
+    <div class="endpoint">
+        <h2>Endpoint Details</h2>
+        <ul>
+            <li><strong>Method:</strong> POST</li>
+            <li><strong>Endpoint:</strong> <code>/api/infer</code></li>
+        </ul>
+    </div>
 
     <h2>Request Body</h2>
+    
     <h3>abilities</h3>
     <p>A dictionary of ability names and their corresponding Ability Point (AP) values. Each ability is represented by an integer AP value, where:</p>
     <ul>
-        <li>A main slot ability has a weight of 10 AP</li>
-        <li>A sub slot ability has a weight of 3 AP</li>
-        <li>Main-Slot-Only abilities should always be represented as 10 AP</li>
+        <li>A main slot ability has a weight of <code>10 AP</code></li>
+        <li>A sub slot ability has a weight of <code>3 AP</code></li>
+        <li>Main-Slot-Only abilities should always be represented as <code>10 AP</code></li>
     </ul>
     <p>The total AP for an ability is the sum of its main and sub slot values. For example, one main (10 AP) and three subs (3 AP each) of Swim Speed Up would be represented as 19 AP.</p>
 
     <h3>weapon_id</h3>
-    <p>An integer representing the unique identifier for a specific weapon in Splatoon 3.</p>
+    <p>An integer representing the unique identifier for a specific weapon in Splatoon 3. The internal ID, where 50 is the ID for 52 gal.</p>
 
     <h2>Example Request</h2>
-    <pre>
-{
+    <pre>{
     "abilities": {
         "swim_speed_up": 19,
         "ninja_squid": 10,
@@ -78,8 +142,7 @@ async def infer_instructions():
         "ink_resist_up": 3
     },
     "weapon_id": 50
-}
-    </pre>
+}</pre>
 
     <h2>Response</h2>
     <p>A list of tuples, each containing:</p>
@@ -87,34 +150,53 @@ async def infer_instructions():
         <li>An ability token (string)</li>
         <li>The predicted value for that token (float)</li>
     </ol>
+    
     <p>Ability tokens are formatted as follows:</p>
     <ul>
-        <li>For main-slot-only abilities: the ability name (e.g., 'ninja_squid')</li>
-        <li>For standard abilities: the ability name followed by a number representing the AP breakpoint (e.g., 'swim_speed_up_3', 'swim_speed_up_6', etc.)</li>
+        <li>For main-slot-only abilities: the ability name (e.g., <code>ninja_squid</code>)</li>
+        <li>For standard abilities: the ability name followed by a number representing the AP breakpoint (e.g., <code>swim_speed_up_3</code>, <code>swim_speed_up_6</code>, etc.)</li>
     </ul>
-    <p>The number in the token represents the minimum AP value for that prediction. For instance, 'swim_speed_up_3' represents the effect of Swim Speed Up with at least 3 AP.</p>
+    <p>The number in the token represents the minimum AP value for that prediction. For instance, <code>swim_speed_up_3</code> represents the effect of Swim Speed Up with at least 3 AP.</p>
 
-    <h2>Note</h2>
-    <p>This endpoint is rate-limited to 10 requests per minute to ensure fair usage and system stability.</p>
+    <div class="note">
+        <h2>Note</h2>
+        <p>This endpoint is rate-limited to 10 requests per minute to ensure fair usage and system stability.</p>
+    </div>
 
     <h2>Ability Lists</h2>
     <h3>Main-Only Abilities</h3>
     <ul>
-        """ + "".join([f"<li>{ability}</li>" for ability in MAIN_ONLY_ABILITIES]) + """
+        """
+        + "".join([f"<li>{ability}</li>" for ability in MAIN_ONLY_ABILITIES])
+        + """
     </ul>
 
     <h3>Standard Abilities</h3>
     <ul>
-        """ + "".join([f"<li>{ability}</li>" for ability in STANDARD_ABILITIES]) + """
+        """
+        + "".join([f"<li>{ability}</li>" for ability in STANDARD_ABILITIES])
+        + """
+    </ul>
+
+    <h3>Special Tokens</h3>
+    <p>There are special tokens that will be returned that should be close to zero probability in the output, here are the meanings:</p>
+    <ul>
+        <li><span class="special-token">&lt;NULL&gt;</span>: Placeholder token to build from no input, safe to ignore</li>
+        <li><span class="special-token">&lt;PAD&gt;</span>: Padding token used in training, safe to ignore</li>
     </ul>
 
     <h2>AP Breakpoints</h2>
     <ul>
-        """ + "".join([f"<li>{breakpoint}</li>" for breakpoint in BUCKET_THRESHOLDS]) + """
+        """
+        + "".join(
+            [f"<li>{breakpoint}</li>" for breakpoint in BUCKET_THRESHOLDS]
+        )
+        + """
     </ul>
 </body>
 </html>
-    """)
+    """
+    )
 
 
 @router.post("/api/infer")


### PR DESCRIPTION
This pull request includes significant updates to improve the user interface and instructions for the SplatGPT Inference API and a minor change to the `Makefile` for Kubernetes deployment. The most important changes include enhancing the HTML response for the inference instructions endpoint and updating the Kubernetes context in the `Makefile`.

Enhancements to SplatGPT Inference API instructions:

* [`src/fast_api_app/routes/infer.py`](diffhunk://#diff-266e88e040ad7aca24f11f85616ad823724f5460b2e1f11084c34db06a8297a5L36-R134): Updated the HTML response to include a new title, improved styling, and additional explanatory sections for better user guidance. [[1]](diffhunk://#diff-266e88e040ad7aca24f11f85616ad823724f5460b2e1f11084c34db06a8297a5L36-R134) [[2]](diffhunk://#diff-266e88e040ad7aca24f11f85616ad823724f5460b2e1f11084c34db06a8297a5L81-R199)

Kubernetes deployment update:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R49): Added a command to switch the Kubernetes context to `kind-kind` before deploying core services.