### PR TITLE
Bugfix/language and column selector

### DIFF
--- a/i18n/EUen.json
+++ b/i18n/EUen.json
@@ -6,7 +6,7 @@
       "USen": "English (US)",
       "USes": "Spanish (NA)",
       "EUen": "English (UK)",
-      "JPja": "Japanese"
+      "JPja": "Japanese (JP) (Beta)"
     }
   },
   "faq": {

--- a/i18n/USen.json
+++ b/i18n/USen.json
@@ -6,7 +6,7 @@
       "USen": "English (US)",
       "USes": "Spanish (NA)",
       "EUen": "English (UK)",
-      "JPjp": "Japanese"
+      "JPja": "Japanese (JP) (Beta)"
     }
   },
   "faq": {

--- a/i18n/USes.json
+++ b/i18n/USes.json
@@ -6,7 +6,7 @@
       "USen": "Inglés (EEUU)",
       "USes": "Español (LATAM)",
       "EUen": "Inglés (RU)",
-      "JPjp": "Japonés"
+      "JPja": "Japonés (JP) (Beta)"
     }
   },
   "faq": {

--- a/src/react_app/src/components/top500_components/selectors/column_selector.jsx
+++ b/src/react_app/src/components/top500_components/selectors/column_selector.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useRef, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 
 const ColumnSelector = ({
@@ -9,6 +9,8 @@ const ColumnSelector = ({
 }) => {
   const { t } = useTranslation();
   const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef(null);
+  const buttonRef = useRef(null);
 
   const handleToggle = (columnId) => {
     if (disabled) return;
@@ -18,10 +20,38 @@ const ColumnSelector = ({
     }));
   };
 
+  useEffect(() => {
+    const handleResize = () => {
+      if (isOpen && dropdownRef.current && buttonRef.current) {
+        const dropdownRect = dropdownRef.current.getBoundingClientRect();
+        const buttonRect = buttonRef.current.getBoundingClientRect();
+        const windowWidth = window.innerWidth;
+
+        if (dropdownRect.right > windowWidth) {
+          const overflowAmount = dropdownRect.right - windowWidth;
+          const newLeftPosition = Math.max(0, buttonRect.left - overflowAmount);
+          dropdownRef.current.style.left = `${newLeftPosition}px`;
+          dropdownRef.current.style.right = "auto";
+        } else {
+          dropdownRef.current.style.left = `${buttonRect.left}px`;
+          dropdownRef.current.style.right = "auto";
+        }
+      }
+    };
+
+    window.addEventListener("resize", handleResize);
+    handleResize();
+
+    return () => {
+      window.removeEventListener("resize", handleResize);
+    };
+  }, [isOpen]);
+
   return (
     <div className="relative inline-block text-left mb-4">
       <div>
         <button
+          ref={buttonRef}
           type="button"
           onClick={() => !disabled && setIsOpen(!isOpen)}
           className={`inline-flex justify-center w-full rounded-md border border-gray-700 px-4 py-2 bg-gray-800 text-sm font-medium text-white ${
@@ -49,7 +79,11 @@ const ColumnSelector = ({
       </div>
 
       {!disabled && isOpen && (
-        <div className="origin-top-right absolute right-0 mt-2 w-56 rounded-md shadow-lg bg-gray-800 ring-1 ring-black ring-opacity-5 focus:outline-none">
+        <div
+          ref={dropdownRef}
+          className="absolute mt-2 w-56 rounded-md shadow-lg bg-gray-800 ring-1 ring-black ring-opacity-5 focus:outline-none"
+          style={{ zIndex: 10 }}
+        >
           <div className="py-1">
             {columnsConfig.map((column) => (
               <label


### PR DESCRIPTION
This pull request includes updates to localization files and enhancements to the `ColumnSelector` component in the React application. The most important changes include updating the Japanese language label in multiple localization files and adding functionality to the `ColumnSelector` component to handle window resizing.

Localization updates:

* [`i18n/EUen.json`](diffhunk://#diff-e63ba3d5c4fd7cd811f159ab90f220cfde6b07ccfd011c8afc4bd2740d02877eL9-R9): Updated the Japanese language label to "Japanese (JP) (Beta)".
* [`i18n/USen.json`](diffhunk://#diff-7e5298055138eb9cc0bfa47e765c69b4358c37f85cef933a1859181d87ba128aL9-R9): Updated the Japanese language label to "Japanese (JP) (Beta)".
* [`i18n/USes.json`](diffhunk://#diff-c13851618294b531f6fa6d9d1d1cb11e857c146cc31554634f04ff21ea84d3c2L9-R9): Updated the Japanese language label to "Japonés (JP) (Beta)".

Enhancements to `ColumnSelector` component:

* [`src/react_app/src/components/top500_components/selectors/column_selector.jsx`](diffhunk://#diff-001fe8fd04af4fa7573b0b8188c62c8ac58b00c177d34b526749e68a821cc7d1L1-R1): Added `useRef` and `useEffect` hooks to manage dropdown positioning on window resize. [[1]](diffhunk://#diff-001fe8fd04af4fa7573b0b8188c62c8ac58b00c177d34b526749e68a821cc7d1L1-R1) [[2]](diffhunk://#diff-001fe8fd04af4fa7573b0b8188c62c8ac58b00c177d34b526749e68a821cc7d1R12-R13) [[3]](diffhunk://#diff-001fe8fd04af4fa7573b0b8188c62c8ac58b00c177d34b526749e68a821cc7d1R23-R54) [[4]](diffhunk://#diff-001fe8fd04af4fa7573b0b8188c62c8ac58b00c177d34b526749e68a821cc7d1L52-R86)