### PR TITLE
fixed client IP not tracking correctly

### DIFF
--- a/src/fast_api_app/connections.py
+++ b/src/fast_api_app/connections.py
@@ -8,11 +8,11 @@ import redis
 from celery import Celery
 from fastapi import WebSocket
 from slowapi import Limiter
-from slowapi.util import get_remote_address
 from sqlalchemy import create_engine
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import scoped_session, sessionmaker
 
+from fast_api_app.utils import get_client_ip
 from shared_lib.constants import REDIS_HOST, REDIS_PORT
 from shared_lib.db import create_uri
 
@@ -124,7 +124,7 @@ sqlite_conn = sqlite3.connect(":memory:")
 sqlite_cursor = sqlite_conn.cursor()
 
 # Create slowapi limiter
-limiter = Limiter(key_func=get_remote_address)
+limiter = Limiter(key_func=get_client_ip)
 
 
 # Model Queue for SplatGPT

--- a/src/fast_api_app/routes/infer.py
+++ b/src/fast_api_app/routes/infer.py
@@ -15,6 +15,7 @@ from fast_api_app.connections import (
     model_queue,
     redis_conn,
 )
+from fast_api_app.utils import get_client_ip
 from shared_lib.constants import (
     BUCKET_THRESHOLDS,
     MAIN_ONLY_ABILITIES,
@@ -268,7 +269,7 @@ async def log_inference_request(
         # Prepare log entry
         log_entry = {
             "request_id": request_id,
-            "ip_address": request.client.host,
+            "ip_address": get_client_ip(request),
             "user_agent": request.headers.get("user-agent"),
             "http_method": request.method,
             "endpoint": str(request.url.path),

--- a/src/fast_api_app/utils.py
+++ b/src/fast_api_app/utils.py
@@ -1,0 +1,16 @@
+from fastapi import Request
+
+
+def get_client_ip(request: Request) -> str:
+    """Get the real client IP address considering proxy headers."""
+    # Check X-Forwarded-For header first
+    forwarded_for = request.headers.get("X-Forwarded-For")
+    if forwarded_for:
+        return forwarded_for.split(",")[0].strip()
+
+    real_ip = request.headers.get("X-Real-IP")
+    if real_ip:
+        return real_ip
+
+    # Fall back to direct client IP
+    return request.client.host

--- a/src/fast_api_app/utils.py
+++ b/src/fast_api_app/utils.py
@@ -3,14 +3,25 @@ from fastapi import Request
 
 def get_client_ip(request: Request) -> str:
     """Get the real client IP address considering proxy headers."""
-    # Check X-Forwarded-For header first
-    forwarded_for = request.headers.get("X-Forwarded-For")
-    if forwarded_for:
-        return forwarded_for.split(",")[0].strip()
 
-    real_ip = request.headers.get("X-Real-IP")
+    forwarded_for = next(
+        (
+            v
+            for k, v in request.headers.items()
+            if k.lower() == "x-forwarded-for"
+        ),
+        None,
+    )
+    if forwarded_for:
+        ip = forwarded_for.split(",")[0].strip()
+        return ip
+
+    real_ip = next(
+        (v for k, v in request.headers.items() if k.lower() == "x-real-ip"),
+        None,
+    )
     if real_ip:
         return real_ip
 
-    # Fall back to direct client IP
-    return request.client.host
+    direct_ip = request.client.host
+    return direct_ip


### PR DESCRIPTION
This pull request focuses on improving how client IP addresses are retrieved and logged in the FastAPI application. The main changes include replacing the `get_remote_address` function with a new `get_client_ip` function and updating relevant parts of the codebase to use this new utility.

### Improvements to client IP address handling:

* [`src/fast_api_app/utils.py`](diffhunk://#diff-eda92b18c7722d90205528425304b1ed5be5f411eb7766d1a574aed155c5a657R1-R16): Added a new `get_client_ip` function to retrieve the real client IP address, considering proxy headers.
* [`src/fast_api_app/connections.py`](diffhunk://#diff-f5e91eb2c75a0595c0eade65555da1aacbfbccc17db5d62204122564c897215eL11-R15): Replaced the import of `get_remote_address` with `get_client_ip` and updated the `Limiter` instantiation to use the new function. [[1]](diffhunk://#diff-f5e91eb2c75a0595c0eade65555da1aacbfbccc17db5d62204122564c897215eL11-R15) [[2]](diffhunk://#diff-f5e91eb2c75a0595c0eade65555da1aacbfbccc17db5d62204122564c897215eL127-R127)
* [`src/fast_api_app/routes/infer.py`](diffhunk://#diff-266e88e040ad7aca24f11f85616ad823724f5460b2e1f11084c34db06a8297a5R18): Imported `get_client_ip` and updated the logging of the IP address in `log_inference_request` to use this new function. [[1]](diffhunk://#diff-266e88e040ad7aca24f11f85616ad823724f5460b2e1f11084c34db06a8297a5R18) [[2]](diffhunk://#diff-266e88e040ad7aca24f11f85616ad823724f5460b2e1f11084c34db06a8297a5L271-R272)