### PR TITLE
Wrap selectors in React.memo

### DIFF
--- a/src/react_app/src/components/top500_components/pagination.jsx
+++ b/src/react_app/src/components/top500_components/pagination.jsx
@@ -32,4 +32,4 @@ const Pagination = ({
   );
 };
 
-export default Pagination;
+export default React.memo(Pagination);

--- a/src/react_app/src/components/top500_components/selectors/mode_selector.jsx
+++ b/src/react_app/src/components/top500_components/selectors/mode_selector.jsx
@@ -84,4 +84,4 @@ const ModeSelector = ({
   );
 };
 
-export default ModeSelector;
+export default React.memo(ModeSelector);

--- a/src/react_app/src/components/top500_components/selectors/region_selector.jsx
+++ b/src/react_app/src/components/top500_components/selectors/region_selector.jsx
@@ -43,4 +43,4 @@ const RegionSelector = ({ selectedRegion, setSelectedRegion }) => {
   );
 };
 
-export default RegionSelector;
+export default React.memo(RegionSelector);


### PR DESCRIPTION
## Summary
- memoize some Top 500 selector components to avoid rerenders

## Testing
- `npm test --silent -- -w=0` *(fails: react-scripts not found)*