### PR TITLE
Feature/delta and fix

### DIFF
--- a/src/react_app/src/components/competition/CompetitionApp.jsx
+++ b/src/react_app/src/components/competition/CompetitionApp.jsx
@@ -41,7 +41,7 @@ const CompetitionLeaderboardPage = ({ snapshot }) => {
     const deltaPlayers = deltas?.players ?? {};
     const hasBaseline = deltas?.baseline_generated_at_ms != null;
     const newcomerIds = new Set(deltas?.newcomers ?? []);
-    const deltaWindowMs = 3 * 24 * 60 * 60 * 1000;
+    const deltaWindowMs = 24 * 60 * 60 * 1000;
 
     const resolveDisplayDelta = (entry) => {
       if (!entry) return null;

--- a/src/react_app/src/components/competition/CompetitionApp.jsx
+++ b/src/react_app/src/components/competition/CompetitionApp.jsx
@@ -23,6 +23,7 @@ const MAIN_SITE_URL = resolveMainSiteUrl();
 
 const CompetitionLeaderboardPage = ({ snapshot }) => {
   const { loading, error, disabled, stable, danger, refresh } = snapshot;
+  const generatedAtMs = stable?.generated_at_ms ?? danger?.generated_at_ms ?? null;
 
   useEffect(() => {
     const previous = document.title;
@@ -35,9 +36,44 @@ const CompetitionLeaderboardPage = ({ snapshot }) => {
   const mergedRows = useMemo(() => {
     const stableRows = Array.isArray(stable?.data) ? stable.data : [];
     const dangerRows = Array.isArray(danger?.data) ? danger.data : [];
+    const deltas = stable?.deltas ?? null;
     const dangerById = new Map(dangerRows.map((row) => [row.player_id, row]));
+    const deltaPlayers = deltas?.players ?? {};
+    const hasBaseline = deltas?.baseline_generated_at_ms != null;
+    const newcomerIds = new Set(deltas?.newcomers ?? []);
+    const deltaWindowMs = 3 * 24 * 60 * 60 * 1000;
+
+    const resolveDisplayDelta = (entry) => {
+      if (!entry) return null;
+      if (typeof entry.display_score_delta === "number") {
+        return entry.display_score_delta;
+      }
+      if (typeof entry.score_delta === "number") {
+        return entry.score_delta * 25;
+      }
+      return null;
+    };
+
     return stableRows.map((row) => {
-      const dangerRow = dangerById.get(row.player_id);
+      const playerId = row.player_id;
+      const dangerRow = dangerById.get(playerId);
+      const deltaEntry = playerId != null ? deltaPlayers[playerId] : undefined;
+      const rankDelta = hasBaseline && deltaEntry && typeof deltaEntry.rank_delta === "number"
+        ? deltaEntry.rank_delta
+        : null;
+      let displayScoreDelta = hasBaseline ? resolveDisplayDelta(deltaEntry) : null;
+      const isNewEntry = hasBaseline && Boolean(deltaEntry?.is_new || newcomerIds.has(playerId));
+      const lastTournamentMs = row.last_tournament_ms ?? null;
+
+      if (
+        displayScoreDelta != null &&
+        generatedAtMs != null &&
+        lastTournamentMs != null &&
+        generatedAtMs - lastTournamentMs > deltaWindowMs
+      ) {
+        displayScoreDelta = null;
+      }
+
       return {
         ...row,
         danger_days_left: dangerRow?.days_left ?? null,
@@ -48,9 +84,21 @@ const CompetitionLeaderboardPage = ({ snapshot }) => {
         // as that incorrectly implies all tournaments occurred in the window.
         window_tournament_count:
           dangerRow?.window_tournament_count ?? row.window_tournament_count ?? null,
+        rank_delta: rankDelta,
+        display_score_delta: displayScoreDelta,
+        delta_is_new: isNewEntry,
+        delta_has_baseline: hasBaseline,
+        delta_previous_rank:
+          deltaEntry && typeof deltaEntry.previous_rank === "number"
+            ? deltaEntry.previous_rank
+            : null,
+        delta_previous_display_score:
+          deltaEntry && typeof deltaEntry.previous_display_score === "number"
+            ? deltaEntry.previous_display_score
+            : null,
       };
     });
-  }, [stable?.data, danger?.data]);
+  }, [stable?.data, stable?.deltas, danger?.data, generatedAtMs]);
 
   if (disabled) {
     return (
@@ -68,7 +116,6 @@ const CompetitionLeaderboardPage = ({ snapshot }) => {
   }
 
   const stale = Boolean(stable?.stale || danger?.stale);
-  const generatedAtMs = stable?.generated_at_ms ?? danger?.generated_at_ms;
   const windowDays = stable?.query_params?.tournament_window_days ?? null;
 
   return (

--- a/src/react_app/src/components/competition/CompetitionFaq.jsx
+++ b/src/react_app/src/components/competition/CompetitionFaq.jsx
@@ -349,11 +349,12 @@ const CompetitionFaq = ({ percentiles }) => {
         <div className="space-y-3">
           <p>
             Only finalized sendou.ink tournaments that are explicitly marked
-            RANKED are used. Byes/forfeits don't create wins or losses. When
-            available, per-match player appearances are preferred; otherwise the
-            team's active roster is used for that match. If you play as a
-            substitute for a match but are not in the active roster, the match
-            will count but the tournament will not for purposes of eligibility.
+            RANKED are used. Byes are ignored, so they do not create wins or
+            losses. When available, per-match player appearances are preferred;
+            otherwise the team's active roster is used for that match. If you
+            play as a substitute for a match but are not in the active roster,
+            the match will count but the tournament will not for purposes of
+            eligibility.
           </p>
         </div>
       ),

--- a/src/shared_lib/constants.py
+++ b/src/shared_lib/constants.py
@@ -48,6 +48,7 @@ SEASON_RESULTS_REDIS_KEY = "season_results"
 # Competition ripple leaderboard cache keys
 RIPPLE_STABLE_STATE_KEY = "ripple:stable:state"
 RIPPLE_STABLE_LATEST_KEY = "ripple:stable:latest"
+RIPPLE_STABLE_DELTAS_KEY = "ripple:stable:deltas"
 RIPPLE_STABLE_META_KEY = "ripple:stable:meta"
 RIPPLE_DANGER_LATEST_KEY = "ripple:danger:latest"
 RIPPLE_STABLE_PERCENTILES_KEY = "ripple:stable:percentiles"


### PR DESCRIPTION
This pull request introduces leaderboard delta tracking to the competition leaderboard, allowing users to see changes in player rank and score compared to the previous leaderboard snapshot. The backend now serves a new deltas payload, and the frontend displays rank and score changes for each player, including indicators for new entrants. Additional UI improvements clarify tournament counting and highlight recent activity.

**Leaderboard Delta Tracking**

* Added backend support for serving leaderboard deltas by introducing the `RIPPLE_STABLE_DELTAS_KEY` constant, a new `_empty_deltas_payload()` helper, and enriching the leaderboard response with deltas data in `ripple_public.py`. [[1]](diffhunk://#diff-cdce80a2a4c98724819f2fe29ce84d1af911c6e1da5b06f30cd07a7ef828c026R13) [[2]](diffhunk://#diff-cdce80a2a4c98724819f2fe29ce84d1af911c6e1da5b06f30cd07a7ef828c026R68-R79) [[3]](diffhunk://#diff-cdce80a2a4c98724819f2fe29ce84d1af911c6e1da5b06f30cd07a7ef828c026L93-R109) [[4]](diffhunk://#diff-f9ddcf3803f576159e7a8dce22f4d5d4600ec7bfa541fa320808a545b2546e6eR51)
* Updated tests to verify that the leaderboard API returns the new deltas payload and its contents. [[1]](diffhunk://#diff-7728a8ed5dae6f7e975da94ffe1446714dc8838f0151f9ae7a336c043bb53ae6R7) [[2]](diffhunk://#diff-7728a8ed5dae6f7e975da94ffe1446714dc8838f0151f9ae7a336c043bb53ae6R59-R79) [[3]](diffhunk://#diff-7728a8ed5dae6f7e975da94ffe1446714dc8838f0151f9ae7a336c043bb53ae6R91-R96)

**Frontend Integration and UI Enhancements**

* Modified `CompetitionApp.jsx` to merge deltas into leaderboard rows, calculate rank/score changes, and flag new entries, with logic to hide deltas for inactive players. [[1]](diffhunk://#diff-91349d9f937c6d550bca791c0344a5ffe53f4c0fdbb9ac12e213edbb99fdccb4R26) [[2]](diffhunk://#diff-91349d9f937c6d550bca791c0344a5ffe53f4c0fdbb9ac12e213edbb99fdccb4R39-R76) [[3]](diffhunk://#diff-91349d9f937c6d550bca791c0344a5ffe53f4c0fdbb9ac12e213edbb99fdccb4R87-R101) [[4]](diffhunk://#diff-91349d9f937c6d550bca791c0344a5ffe53f4c0fdbb9ac12e213edbb99fdccb4L71)
* Updated `StableLeaderboardTable.jsx` to display rank and score change indicators in both desktop and mobile views, style tournament window counts, and propagate delta metadata through row rendering. [[1]](diffhunk://#diff-c17e40e4508a03eec0647ad34262136672bdadde9d53133d68016e9397c5fea2R93-R103) [[2]](diffhunk://#diff-c17e40e4508a03eec0647ad34262136672bdadde9d53133d68016e9397c5fea2R161-R195) [[3]](diffhunk://#diff-c17e40e4508a03eec0647ad34262136672bdadde9d53133d68016e9397c5fea2R209-R219) [[4]](diffhunk://#diff-c17e40e4508a03eec0647ad34262136672bdadde9d53133d68016e9397c5fea2R278-R287) [[5]](diffhunk://#diff-c17e40e4508a03eec0647ad34262136672bdadde9d53133d68016e9397c5fea2L249-R319) [[6]](diffhunk://#diff-c17e40e4508a03eec0647ad34262136672bdadde9d53133d68016e9397c5fea2L279-R358) [[7]](diffhunk://#diff-c17e40e4508a03eec0647ad34262136672bdadde9d53133d68016e9397c5fea2L299-R377) [[8]](diffhunk://#diff-c17e40e4508a03eec0647ad34262136672bdadde9d53133d68016e9397c5fea2R599-R608) [[9]](diffhunk://#diff-c17e40e4508a03eec0647ad34262136672bdadde9d53133d68016e9397c5fea2R624-R631) [[10]](diffhunk://#diff-c17e40e4508a03eec0647ad34262136672bdadde9d53133d68016e9397c5fea2R670-R677) [[11]](diffhunk://#diff-c17e40e4508a03eec0647ad34262136672bdadde9d53133d68016e9397c5fea2L599-R700)

**Copy and Clarity Improvements**

* Clarified FAQ copy to specify that byes are ignored and do not create wins or losses in tournament counting.