### PR TITLE
chore: clean up maintenance warnings

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,7 +27,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 
@@ -51,4 +51,3 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.anthropic.com/en/docs/claude-code/sdk#command-line for available options
           claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
-

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,7 +26,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 
@@ -47,4 +47,3 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.anthropic.com/en/docs/claude-code/sdk#command-line for available options
           # claude_args: '--model claude-opus-4-1-20250805 --allowed-tools Bash(gh pr:*)'
-

--- a/.github/workflows/monitoring-snapshots.yml
+++ b/.github/workflows/monitoring-snapshots.yml
@@ -22,7 +22,7 @@ jobs:
     environment: SplatTop
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/sync_competition_admins_to_config.yml
+++ b/.github/workflows/sync_competition_admins_to_config.yml
@@ -18,7 +18,7 @@ jobs:
     environment: SplatTop
     steps:
       - name: Checkout app repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Require config repo token
         env:
@@ -39,7 +39,7 @@ jobs:
         run: python -m pip install --upgrade pip ruamel.yaml
 
       - name: Checkout config repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: cesaregarza/SplatTopConfig
           token: ${{ secrets.CONFIG_REPO_TOKEN }}

--- a/.github/workflows/update_assets.yml
+++ b/.github/workflows/update_assets.yml
@@ -13,7 +13,7 @@ jobs:
     environment: SplatTop
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/update_k8s_deployment.yaml
+++ b/.github/workflows/update_k8s_deployment.yaml
@@ -54,7 +54,7 @@ jobs:
       exit_pipeline: ${{ steps.finalize.outputs.exit_pipeline }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -148,7 +148,7 @@ jobs:
       react_digest: ${{ steps.build_react.outputs.digest }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -256,10 +256,10 @@ jobs:
     environment: SplatTop
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Checkout config repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: cesaregarza/SplatTopConfig
           path: config-repo
@@ -363,7 +363,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Create GitHub release if missing
         env:
@@ -474,7 +474,7 @@ jobs:
           path: metadata
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: app-repo
 
@@ -482,7 +482,7 @@ jobs:
         run: python3 -m pip install --user "ruamel.yaml>=0.18.6,<0.19"
 
       - name: Checkout config repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: cesaregarza/SplatTopConfig
           token: ${{ secrets.CONFIG_REPO_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -10,13 +10,19 @@ A platform showcasing the Top 500 players in Splatoon 3, with historical ranking
   - An Nginx Ingress controller
   - Cert-Manager for SSL/TLS certificates (production only)
 
-Deployment is handled via Kubernetes (DigitalOcean Kubernetes Service in production), with continuous integration and deployment via GitHub Actions. Local development can be done using Docker & kind or by running components individually.
+Deployment is split across two repositories:
+
+- `SplatTop` builds and publishes application images
+- `SplatTopConfig` owns Helm values, Argo CD applications, and encrypted production secrets
+
+Production runs on DigitalOcean Kubernetes and is applied from `SplatTopConfig` via Argo CD. Local development can be done using Docker & kind or by running components individually.
 
 ## Prerequisites
 
 - Docker & kind (`kubectl`) for Kubernetes-based local development
 - Python 3.10+ & Poetry for backend dependencies and scripts
 - Node.js & npm for frontend development
+- A sibling clone of `../SplatTopConfig` if you need to inspect or update production Helm/Argo state
 - (Optional) Access to a `secrets.yaml` or a local `.env` file containing database credentials and ML storage settings
 
 We welcome contributions for localizations! If you are interested in helping translate SplatTop into other languages, please refer to the [Contributing Localizations](LOCALIZING.md) section.
@@ -26,6 +32,7 @@ We welcome contributions for localizations! If you are interested in helping tra
 - [Installation](#installation)
   - [Local Development](#local-development)
   - [Secrets Configuration](#secrets-configuration)
+- [Infrastructure & Releases](#infrastructure--releases)
 - [Architecture](#architecture)
     - [Frontend Pod](#frontend-pod)
     - [Backend Pod](#backend-pod)
@@ -43,7 +50,7 @@ We welcome contributions for localizations! If you are interested in helping tra
   - [Rate Limiting](#rate-limiting)
   - [Usage Logging & Flush](#usage-logging--flush)
   - [Proxy Headers & Client IP](#proxy-headers--client-ip)
-  - [Deployment/Migration Notes](#deploymentmigration-notes)
+- [Deployment/Migration Notes](#deploymentmigration-notes)
 
 ## Installation
 
@@ -54,6 +61,7 @@ You can run SplatTop locally without Kubernetes by starting each component manua
 1. **Clone the Repository**:
    ```sh
    git clone https://github.com/cesaregarza/SplatTop.git
+   git clone https://github.com/cesaregarza/SplatTopConfig.git ../SplatTopConfig
    cd SplatTop
    ```
 
@@ -126,8 +134,6 @@ Ingress (pre-prod): http://localhost:8080
 
 ### Secrets Configuration
 
-### Secrets Configuration
-
 Sensitive settings (database credentials, ML storage endpoints) should be provided via environment variables in `.env`, or via `secrets.yaml` when deploying on Kubernetes.
 
 1. **Local `.env`**:
@@ -163,19 +169,30 @@ Sensitive settings (database credentials, ML storage endpoints) should be provid
    - Merge the encrypted-file change to `main`, then `.github/workflows/sync_competition_admins_to_config.yml` opens the `SplatTopConfig` PR that copies the encrypted secret and ensures the Helm/Argo wiring exists.
    - The app-repo workflow expects `CONFIG_REPO_TOKEN`. Plaintext admin IDs are not passed through GitHub Actions inputs.
 
+## Infrastructure & Releases
+
+The quick version:
+
+- application code, tests, Dockerfiles, and CI live in this repo
+- production Helm values, Argo apps, and encrypted prod secrets live in `../SplatTopConfig`
+- merging to `SplatTop/main` publishes images and proposes config changes
+- production only changes after `SplatTopConfig` is updated and Argo syncs `splattop-prod`
+
+The detailed guide is in [docs/infrastructure-and-release.md](docs/infrastructure-and-release.md).
+
 ## Architecture
 
 ### Frontend Pod
 The frontend pod hosts the React application on Nginx. It serves the user interface of SplatTop, enabling users to interact with the website and view the Top 500 players and their ranking history. This pod communicates exclusively with the backend pod to fetch data and update the UI based on user actions, and it cannot access the rest of the Kubernetes cluster. While currently written in JavaScript and JSX, a migration to TypeScript and TSX is planned for the near future.
 
 ### Backend Pod
-The backend pod runs a FastAPI application hosted on Gunicorn with Uvicorn workers. It handles API requests from the frontend, processes data, communicates with Redis and the database, and exposes websocket endpoints for real-time updates.
+The backend pod runs a FastAPI application hosted on Gunicorn with Uvicorn workers. It handles API requests from the frontend, communicates with Redis and PostgreSQL, and exposes websocket endpoints for real-time updates. FastAPI no longer owns the heavyweight lookup-table refresh loop in production; it reads a published lookup snapshot built by Celery.
 
 ### Database
-Persistent player and leaderboard data is stored in PostgreSQL. Database connection is configured via environment variables (DB_HOST, DB_PORT, DB_USER, DB_PASSWORD, DB_NAME). For local caching and development, SQLite is used for read-only or non-critical data stores.
+Persistent player and leaderboard data is stored in PostgreSQL. Database connection is configured via environment variables (`DB_HOST`, `DB_PORT`, `DB_USER`, `DB_PASSWORD`, `DB_NAME`). SQLite is still used locally inside the app stack, but the important production lookup path is now a Celery-built, Redis-published, FastAPI-consumed read-only snapshot.
 
 ### Cache/Message Broker/PubSub Pod
-The Redis pod functions as a cache, message broker, and PubSub system. Celery workers use Redis to queue tasks and store results. The backend caches frequently accessed leaderboard snapshots in Redis. Redis PubSub channels are used for real-time player detail updates.
+The Redis pod functions as a cache, message broker, and PubSub system. Celery workers use Redis to queue tasks and store results. The backend caches frequently accessed leaderboard snapshots in Redis. Redis PubSub channels are used for real-time player detail updates, and Redis also carries the compressed lookup SQLite snapshot metadata/blob used by FastAPI search and weapon leaderboard routes.
 
 ### Workers Pod
 The workers pod runs Celery workers that handle asynchronous tasks such as:
@@ -183,12 +200,13 @@ The workers pod runs Celery workers that handle asynchronous tasks such as:
   - Fetching weapon info and aliases
   - Computing analytics (Lorenz curves, Gini coefficients, skill offsets)
   - Populating Redis caches and database tables
+  - Building and publishing lookup SQLite snapshots consumed by FastAPI
 
 ### Inference Service Pod
 The machine learning inference service (SplatGPT) provides loadout recommendations via a REST API on port 9000. It can be run as a separate Docker image (`splatnlp:latest`) and communicates with the backend or external storage (e.g., DigitalOcean Spaces) to load models and data.
 
 ### Task Scheduler Pod
-The task scheduler pod runs Celery Beat, which schedules periodic tasks (e.g., data pulls, analytics updates) for the Celery workers according to `src/celery_app/beat.py` schedules.
+The task scheduler pod runs Celery Beat, which schedules periodic tasks (e.g., data pulls, analytics updates, lookup snapshot refreshes) for the Celery workers according to `src/celery_app/beat.py` schedules.
 
 ### Ingress Controller Pod
 The ingress controller pod uses Nginx to manage incoming traffic to the Kubernetes cluster. It routes requests to the appropriate services based on predefined rules, ensuring that users can access the frontend and backend services. This is not used in the `-dev` environment, as the frontend and backend communicate directly with each other.

--- a/docs/infrastructure-and-release.md
+++ b/docs/infrastructure-and-release.md
@@ -55,6 +55,62 @@ The Argo app name is:
 
 - `splattop-prod`
 
+## Diagrams
+
+### Production topology
+
+```mermaid
+flowchart LR
+    User[Users / Browsers]
+    Ingress[Nginx Ingress]
+
+    subgraph Cluster[DigitalOcean Kubernetes cluster]
+        React[React deployment]
+        FastAPI[FastAPI deployment]
+        Redis[(Redis)]
+        Worker[Celery worker]
+        Beat[Celery beat]
+        SplatNLP[SplatNLP]
+    end
+
+    PG[(PostgreSQL)]
+
+    User --> Ingress
+    Ingress --> React
+    Ingress --> FastAPI
+    React --> FastAPI
+    FastAPI --> Redis
+    FastAPI --> PG
+    FastAPI --> SplatNLP
+    Beat --> Redis
+    Redis --> Worker
+    Worker --> Redis
+    Worker --> PG
+    Worker --> SplatNLP
+    Worker -->|publish lookup snapshot| Redis
+    FastAPI -->|read lookup snapshot metadata/blob| Redis
+```
+
+### Release and deploy flow
+
+```mermaid
+flowchart LR
+    AppRepo[SplatTop main]
+    AppCI[GitHub Actions build workflow]
+    Registry[DigitalOcean Container Registry]
+    Release[GitHub release tag]
+    ConfigRepo[SplatTopConfig main]
+    Argo[Argo CD<br/>splattop-prod]
+    Prod[Production Kubernetes]
+
+    AppRepo --> AppCI
+    AppCI --> Registry
+    AppCI --> Release
+    AppCI -->|opens PR / updates tags| ConfigRepo
+    ConfigRepo --> Argo
+    Argo --> Prod
+```
+
 ## Release Flow
 
 ### Normal application release

--- a/docs/infrastructure-and-release.md
+++ b/docs/infrastructure-and-release.md
@@ -1,0 +1,156 @@
+# Infrastructure and Release Guide
+
+SplatTop production is split across two repositories:
+
+- `SplatTop` (this repo): application code, Dockerfiles, tests, and GitHub Actions that build/publish images
+- `SplatTopConfig`: Helm chart values, Argo CD Applications, encrypted secrets, and the desired production state
+
+This document is the practical map of how those pieces fit together.
+
+## Repo Responsibilities
+
+### `SplatTop`
+
+Owns:
+
+- FastAPI, Celery, React, and shared Python/JS code
+- Docker image build definitions in `dockerfiles/`
+- CI/CD workflows in `.github/workflows/`
+- local kind manifests under `k8s/`
+- helper scripts for secret sync and release automation
+
+Does **not** own the live production manifests. A merge to `main` here publishes images and proposes config updates, but production still reads desired state from `SplatTopConfig`.
+
+### `SplatTopConfig`
+
+Owns:
+
+- Helm chart values for development and production
+- Argo CD `Application` resources
+- encrypted production secrets
+- component tag metadata (`automation/component-tags.json`)
+- the production image tags consumed by Argo/Helm
+
+Production tracks `SplatTopConfig/main`, not `SplatTop/main`.
+
+## Production Topology
+
+Production runs on DigitalOcean Kubernetes and is managed through Argo CD.
+
+Core workloads:
+
+- `splattop-prod-fastapi`
+- `splattop-prod-react`
+- `splattop-prod-celery-worker`
+- `splattop-prod-celery-beat`
+- `splattop-prod-redis`
+- `splattop-prod-splatnlp`
+
+Important namespace notes:
+
+- the Argo `Application` lives in namespace `argocd`
+- the actual SplatTop production workloads currently run in namespace `default`
+
+The Argo app name is:
+
+- `splattop-prod`
+
+## Release Flow
+
+### Normal application release
+
+1. Merge app changes to `SplatTop/main`.
+2. `.github/workflows/update_k8s_deployment.yaml` detects changed components.
+3. GitHub Actions builds only the changed images and publishes:
+   - `registry.digitalocean.com/sendouq/fast-api:vX.Y.Z`
+   - `registry.digitalocean.com/sendouq/celery:vX.Y.Z`
+   - `registry.digitalocean.com/sendouq/react:vX.Y.Z`
+4. The workflow creates or updates the GitHub release tag and emits `component-tags.json`.
+5. The workflow opens a PR against `SplatTopConfig` to bump the affected Helm image tags and refresh `automation/component-tags.json`.
+6. After `SplatTopConfig/main` is updated, Argo can sync `splattop-prod` to roll the new version.
+
+### Secret sync flow
+
+Competition auth secrets follow a different path:
+
+1. Update `secrets/competition-admins/comp-auth-secrets.enc.yaml` in `SplatTop`.
+2. `.github/workflows/sync_competition_admins_to_config.yml` copies that state into `SplatTopConfig`.
+3. The workflow opens a PR in `SplatTopConfig`.
+4. After that PR merges, Argo sync applies the new secret wiring.
+
+## What Changed In The Lookup Snapshot Refactor
+
+Historically, FastAPI owned the local SQLite lookup refreshers for:
+
+- aliases
+- weapon leaderboard peak data
+- season results
+
+That was simple, but it meant request-serving FastAPI pods also performed heavyweight rebuild work. Under load, that created avoidable latency spikes.
+
+The current production path is:
+
+1. Celery tasks build a combined lookup SQLite snapshot.
+2. The snapshot is compressed and published to Redis.
+3. FastAPI reads the published snapshot into a local file-backed read-only SQLite database.
+4. Search and weapon leaderboard endpoints query that local snapshot.
+
+Relevant code:
+
+- snapshot build task: `src/celery_app/tasks/sqlite_lookup_snapshot.py`
+- schedule registration: `src/celery_app/beat.py`
+- FastAPI snapshot loader: `src/fast_api_app/sqlite_lookup_store.py`
+- consumers:
+  - `src/fast_api_app/routes/search.py`
+  - `src/fast_api_app/routes/weapon_leaderboard.py`
+
+Operational consequence:
+
+- FastAPI should be treated as read-only for those lookup datasets in production.
+- If the lookup snapshot is missing after a rollout, trigger `tasks.refresh_lookup_sqlite_snapshot` once from Celery and confirm `lookup_sqlite:meta` exists in Redis.
+
+## Operational Checklist
+
+### Before syncing production
+
+- confirm the app workflow on `SplatTop` finished successfully
+- confirm the expected release tag exists on GitHub
+- confirm `SplatTopConfig/main` points the correct components at that tag
+
+### After syncing production
+
+- check Argo:
+  - `kubectl --context do-nyc3-k8s-nyc3-splattop -n argocd get application splattop-prod`
+- check rollout status:
+  - `kubectl --context do-nyc3-k8s-nyc3-splattop -n default rollout status deployment/splattop-prod-fastapi`
+  - `kubectl --context do-nyc3-k8s-nyc3-splattop -n default rollout status deployment/splattop-prod-celery-worker`
+  - `kubectl --context do-nyc3-k8s-nyc3-splattop -n default rollout status deployment/splattop-prod-celery-beat`
+- confirm deployed images:
+  - `kubectl --context do-nyc3-k8s-nyc3-splattop -n default get deploy splattop-prod-fastapi splattop-prod-celery-worker splattop-prod-celery-beat -o jsonpath='{range .items[*]}{.metadata.name}{\" => \"}{range .spec.template.spec.containers[*]}{.image}{\" \"}{end}{\"\\n\"}{end}'`
+
+### Lookup snapshot sanity checks
+
+- confirm Redis metadata:
+  - `kubectl --context do-nyc3-k8s-nyc3-splattop -n default exec deploy/splattop-prod-redis -- redis-cli GET lookup_sqlite:meta`
+- if needed, warm the snapshot explicitly:
+  - `kubectl --context do-nyc3-k8s-nyc3-splattop -n default exec deploy/splattop-prod-celery-worker -- celery -A celery_app.app call tasks.refresh_lookup_sqlite_snapshot`
+
+## Local Development Notes
+
+The local kind path still lives in this repo under `k8s/`, but production Helm/Argo manifests are in `SplatTopConfig`.
+
+For local work:
+
+- use `.env` for manual service startup
+- use `k8s/secrets.dev.enc.yaml` for kind/Helm-based local development
+- keep a local clone of `../SplatTopConfig` available if you need to diff or test production Helm values
+
+## When To Update This Doc
+
+Update this file when any of these change:
+
+- the app/config repo boundary
+- the production release workflow
+- Argo application names or namespaces
+- the ownership of background refresh work between FastAPI and Celery
+- the manual post-deploy checks required for production safety

--- a/src/celery_app/tasks/front_page.py
+++ b/src/celery_app/tasks/front_page.py
@@ -207,7 +207,7 @@ def process_all_data(df: pd.DataFrame) -> list[tuple[str, pd.DataFrame]]:
     df = df.loc[:, keys_to_keep]
     out = []
     for region in REGIONS:
-        logger.info(f"Processing data for region: {region}")
+        logger.info("Processing data for region: %s", region)
         region_df = df.loc[df["region"] == region]
         region_df = process_region_data(region_df)
         for mode in MODES_SNAKE_CASE.values():
@@ -295,7 +295,7 @@ def pull_data() -> None:
         redis_conn.set(
             redis_key, processed_df.reset_index().to_json(orient="records")
         )
-        logger.info(f"All data for region: {region} saved to Redis")
+        logger.info("All data for region: %s saved to Redis", region)
         if metrics_enabled():
             DATA_PULL_ROWS.labels(
                 task=f"front_page.leaderboard_payload:{region}"

--- a/src/fast_api_app/background_tasks.py
+++ b/src/fast_api_app/background_tasks.py
@@ -36,8 +36,10 @@ class BackgroundRunner:
         start = perf_counter()
         try:
             manager.update_database()
-        except Exception as e:
-            logger.error(f"Error updating table {manager.table_name}: {e}")
+        except Exception:
+            logger.exception(
+                "Error updating table %s", manager.table_name
+            )
             sleep_time = manager.retry_cadence
             outcome = "error"
         finally:

--- a/src/fast_api_app/pubsub.py
+++ b/src/fast_api_app/pubsub.py
@@ -28,7 +28,9 @@ async def process_pubsub_message(pubsub: PubSub):
                 if metrics_enabled():
                     PUBSUB_EVENTS.labels(event="decode_error").inc()
                 continue
-            logger.info(f"Received player data for: {data['player_id']}")
+            logger.info(
+                "Received player data for: %s", data["player_id"]
+            )
             if metrics_enabled():
                 PUBSUB_EVENTS.labels(event="message").inc()
             if data.get("type") == "player_chunk":
@@ -78,15 +80,15 @@ async def listen_for_updates():
     while True:
         pubsub = redis_conn.pubsub()
         pubsub.subscribe(PLAYER_PUBSUB_CHANNEL)
-        logger.info(f"Subscribed to channel: {PLAYER_PUBSUB_CHANNEL}")
+        logger.info("Subscribed to channel: %s", PLAYER_PUBSUB_CHANNEL)
         if metrics_enabled():
             PUBSUB_RESTARTS.inc()
             PUBSUB_ACTIVE.set(1)
 
         try:
             await process_pubsub_message(pubsub)
-        except Exception as e:
-            logger.error(f"Error in pubsub listener: {e}")
+        except Exception:
+            logger.exception("Error in pubsub listener")
             if metrics_enabled():
                 PUBSUB_EVENTS.labels(event="listener_error").inc()
         finally:

--- a/src/fast_api_app/routes/infer.py
+++ b/src/fast_api_app/routes/infer.py
@@ -378,8 +378,8 @@ async def log_inference_request(
                     )
                     session.add(new_log_entry)
                     await session.commit()
-        except Exception as db_error:
-            logger.error(f"Failed to log inference request: {db_error}")
+        except Exception:
+            logger.exception("Failed to log inference request")
 
 
 @router.post("/api/infer")
@@ -419,7 +419,7 @@ async def infer(inference_request: InferenceRequest, request: Request):
     model_request: dict | None = None
 
     if cached_result:
-        logger.info(f"Cache hit, hash: {abilities_hash}")
+        logger.info("Cache hit, hash: %s", abilities_hash)
         cache_status = "hit"
         try:
             predictions = eval(cached_result)
@@ -434,7 +434,7 @@ async def infer(inference_request: InferenceRequest, request: Request):
                 "weapon_id": inference_request.weapon_id,
             }
     else:
-        logger.info(f"Cache miss, hash: {abilities_hash}")
+        logger.info("Cache miss, hash: %s", abilities_hash)
         model_request = {
             "target": inference_request.abilities,
             "weapon_id": inference_request.weapon_id,
@@ -465,8 +465,8 @@ async def infer(inference_request: InferenceRequest, request: Request):
                     exc_info=True,
                 )
 
-        except Exception as e:
-            logger.error(f"Error sending request to model server: {e}")
+        except Exception:
+            logger.exception("Error sending request to model server")
             if metrics_enabled():
                 SPLATGPT_ERRORS.labels(stage="model_request").inc()
             raise HTTPException(
@@ -529,6 +529,6 @@ async def feedback(feedback_request: FeedbackRequest):
         )
         return {"status": f"{status_message} successfully"}
 
-    except Exception as e:
-        logger.error(f"Error logging feedback: {e}")
+    except Exception:
+        logger.exception("Error logging feedback")
         raise HTTPException(status_code=500, detail="Error logging feedback")

--- a/src/fast_api_app/routes/search.py
+++ b/src/fast_api_app/routes/search.py
@@ -25,7 +25,7 @@ async def search(query: str, request: Request):
             detail="Data is not available yet, please wait.",
         )
 
-    logger.info(f"Searching for: {query}")
+    logger.info("Searching for: %s", query)
     formatted_key = f"%{query}%"
     start = perf_counter()
     result = lookup_fetchall(
@@ -37,5 +37,5 @@ async def search(query: str, request: Request):
     if metrics_enabled():
         SEARCH_LATENCY.labels(outcome=outcome).observe(duration)
         SEARCH_RESULTS.labels(outcome=outcome).inc()
-    logger.info(f"Search complete for: {query}")
+    logger.info("Search complete for: %s", query)
     return result

--- a/src/fast_api_app/sqlite_tables/main.py
+++ b/src/fast_api_app/sqlite_tables/main.py
@@ -12,7 +12,7 @@ class TableManager(ABC):
         cadence: int = 600,
         retry_cadence: int = 60,
     ):
-        logger.info(f"Initializing TableManager for {table_name}")
+        logger.info("Initializing TableManager for %s", table_name)
         self.table_name = table_name
         self.redis_key = redis_key
         self.cadence = cadence

--- a/src/shared_lib/models.py
+++ b/src/shared_lib/models.py
@@ -17,7 +17,7 @@ from sqlalchemy import (
     text,
 )
 from sqlalchemy.dialects.postgresql import ENUM, INET, JSONB
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 
 Base = declarative_base()
 


### PR DESCRIPTION
## Summary
- upgrade workflow checkouts to `actions/checkout@v5`
- switch `shared_lib.models` to `sqlalchemy.orm.declarative_base`
- normalize a small set of backend logs to structured logging and `logger.exception`

## Why
- removes the SQLAlchemy 2.x deprecation warning from test imports
- reduces eager log string interpolation and preserves stack traces on real exceptions
- addresses the GitHub Actions `checkout@v4` Node 20 deprecation warning without changing workflow behavior

## Verification
- `uv run pytest tests/test_app_startup.py tests/test_lookup_snapshot_routes.py -q`
- grep check confirmed the touched files no longer contain `actions/checkout@v4`, `sqlalchemy.ext.declarative`, or the old logger f-string patterns