### PR TITLE
[codex] Add archive nav label to source locales

### DIFF
--- a/i18n/CNzh.json
+++ b/i18n/CNzh.json
@@ -154,6 +154,7 @@
     "footer.about": "关于",
     "footer.contact": "联系我们",
     "footer.rights": "%DATE% splat.top. All rights reserved.",
+    "navbar.legacy": "存档",
     "navbar.faq": "常见问题",
     "navbar.analytics": "分析",
     "navbar.top_weapons": "顶级武器"

--- a/i18n/EUen.json
+++ b/i18n/EUen.json
@@ -154,6 +154,7 @@
     "footer.about": "About",
     "footer.contact": "Contact",
     "footer.rights": "%DATE% splat.top. All rights reserved.",
+    "navbar.legacy": "Archive",
     "navbar.faq": "FAQ",
     "navbar.analytics": "Analytics",
     "navbar.top_weapons": "Top Weapons"

--- a/i18n/JPja.json
+++ b/i18n/JPja.json
@@ -179,6 +179,7 @@
     "footer.about": "About",
     "footer.contact": "Contact",
     "footer.rights": "%DATE% splat.top. All rights reserved.",
+    "navbar.legacy": "アーカイブ",
     "navbar.faq": "FAQ",
     "navbar.analytics": "分析",
     "navbar.top_weapons": "ブキ使用率"

--- a/i18n/USen.json
+++ b/i18n/USen.json
@@ -179,6 +179,7 @@
     "footer.about": "About",
     "footer.contact": "Contact",
     "footer.rights": "%DATE% splat.top. All rights reserved.",
+    "navbar.legacy": "Archive",
     "navbar.faq": "FAQ",
     "navbar.analytics": "Analytics",
     "navbar.top_weapons": "Top Weapons"

--- a/i18n/USes.json
+++ b/i18n/USes.json
@@ -154,6 +154,7 @@
     "footer.about": "Acerca de",
     "footer.contact": "Contacto",
     "footer.rights": "%DATE% splat.top. Todos los derechos reservados.",
+    "navbar.legacy": "Archivo",
     "navbar.faq": "FAQ",
     "navbar.analytics": "Analítica",
     "navbar.top_weapons": "Top Weapons"


### PR DESCRIPTION
## Summary
- add the missing `navbar.legacy` entry to the source locale files in `i18n/*.json`

## Why
- the React locale shards under `src/react_app/public/locales` were updated, but the source locale files in `i18n/*.json` were not
- the i18n workflow regenerates the React locale shards from `i18n/*.json`, so production could fall back to the literal `navbar.legacy` key after regeneration or deploy

## Root Cause
- the source-of-truth locale files were missing the new navigation key even though the generated locale files already had it

## Validation
- verified `navbar.legacy` exists in both `i18n/*.json` and `src/react_app/public/locales/*/navigation.json`
