### PR TITLE
Remove per-player cardinality from websocket Prometheus metrics

### DIFF
--- a/src/fast_api_app/connections.py
+++ b/src/fast_api_app/connections.py
@@ -104,8 +104,11 @@ class ConnectionManager:
         }
         if metrics_enabled():
             WEBSOCKET_EVENTS.labels(event="connected").inc()
-            WEBSOCKET_CONNECTIONS.labels(player_id=player_id).set(
-                len(self.active_connections[player_id])
+            WEBSOCKET_CONNECTIONS.set(
+                sum(
+                    len(connections)
+                    for connections in self.active_connections.values()
+                )
             )
         logger.info(
             "Client connected and added to room: %s with connection id: %s (progressive=%s)",
@@ -255,16 +258,13 @@ class ConnectionManager:
             del self.active_connections[player_id][connection_id]
             if not self.active_connections[player_id]:
                 del self.active_connections[player_id]
-                if metrics_enabled():
-                    try:
-                        WEBSOCKET_CONNECTIONS.remove(player_id)
-                    except KeyError:
-                        pass
-            elif metrics_enabled():
-                WEBSOCKET_CONNECTIONS.labels(player_id=player_id).set(
-                    len(self.active_connections[player_id])
-                )
             if metrics_enabled():
+                WEBSOCKET_CONNECTIONS.set(
+                    sum(
+                        len(connections)
+                        for connections in self.active_connections.values()
+                    )
+                )
                 WEBSOCKET_EVENTS.labels(event="disconnected").inc()
             logger.info(
                 "Client disconnected, id: %s, connection id: %s",
@@ -335,12 +335,8 @@ class ConnectionManager:
             if metrics_enabled():
                 duration = perf_counter() - start
                 WEBSOCKET_EVENTS.labels(event="broadcast").inc(recipients)
-                WEBSOCKET_BROADCAST_DURATION.labels(
-                    player_id=player_id
-                ).observe(duration)
-                WEBSOCKET_BYTES_SENT.labels(player_id=player_id).inc(
-                    len(compressed_message) * recipients
-                )
+                WEBSOCKET_BROADCAST_DURATION.observe(duration)
+                WEBSOCKET_BYTES_SENT.inc(len(compressed_message) * recipients)
             logger.info("Compressed data sent")
         else:
             logger.info("Player %s not connected", player_id)

--- a/src/fast_api_app/pubsub.py
+++ b/src/fast_api_app/pubsub.py
@@ -35,9 +35,7 @@ async def process_pubsub_message(pubsub: PubSub):
                 PUBSUB_EVENTS.labels(event="message").inc()
             if data.get("type") == "player_chunk":
                 if metrics_enabled():
-                    PUBSUB_BYTES_BROADCAST.labels(
-                        player_id=data.get("player_id", "unknown")
-                    ).inc(len(raw_message))
+                    PUBSUB_BYTES_BROADCAST.inc(len(raw_message))
                 await connection_manager.broadcast_player_data(
                     raw_message,
                     data["player_id"],
@@ -50,9 +48,7 @@ async def process_pubsub_message(pubsub: PubSub):
                             PUBSUB_EVENTS.labels(event="cache_miss").inc()
                         continue
                     if metrics_enabled():
-                        PUBSUB_BYTES_BROADCAST.labels(
-                            player_id=data.get("player_id", "unknown")
-                        ).inc(len(player_data))
+                        PUBSUB_BYTES_BROADCAST.inc(len(player_data))
                     await connection_manager.broadcast_player_data(
                         player_data,
                         data["player_id"],
@@ -66,9 +62,7 @@ async def process_pubsub_message(pubsub: PubSub):
                     PUBSUB_EVENTS.labels(event="cache_miss").inc()
                 continue
             if metrics_enabled():
-                PUBSUB_BYTES_BROADCAST.labels(
-                    player_id=data.get("player_id", "unknown")
-                ).inc(len(player_data))
+                PUBSUB_BYTES_BROADCAST.inc(len(player_data))
             await connection_manager.broadcast_player_data(
                 player_data, data["player_id"]
             )

--- a/src/shared_lib/monitoring/prometheus.py
+++ b/src/shared_lib/monitoring/prometheus.py
@@ -68,8 +68,7 @@ SPLATGPT_ERRORS = Counter(
 
 WEBSOCKET_CONNECTIONS = Gauge(
     "fastapi_websocket_connections",
-    "Active websocket connections grouped by player id.",
-    labelnames=["player_id"],
+    "Total active websocket connections.",
 )
 WEBSOCKET_EVENTS = Counter(
     "fastapi_websocket_events_total",
@@ -79,12 +78,10 @@ WEBSOCKET_EVENTS = Counter(
 WEBSOCKET_BROADCAST_DURATION = Histogram(
     "fastapi_websocket_broadcast_duration_seconds",
     "Duration of websocket broadcast operations.",
-    labelnames=["player_id"],
 )
 WEBSOCKET_BYTES_SENT = Counter(
     "fastapi_websocket_bytes_total",
     "Total bytes of websocket payloads sent.",
-    labelnames=["player_id"],
 )
 
 TABLE_REFRESH_DURATION = Histogram(
@@ -119,7 +116,6 @@ PUBSUB_ACTIVE = Gauge(
 PUBSUB_BYTES_BROADCAST = Counter(
     "fastapi_pubsub_bytes_total",
     "Bytes broadcast to websocket subscribers via pubsub.",
-    labelnames=["player_id"],
 )
 
 RATE_LIMIT_EVENTS = Counter(

--- a/tests/test_websocket_metrics.py
+++ b/tests/test_websocket_metrics.py
@@ -1,0 +1,223 @@
+import asyncio
+import importlib
+import json
+import zlib
+
+import pytest
+
+from shared_lib.monitoring import prometheus
+
+
+class _AggregateMetricSpy:
+    def __init__(self):
+        self.set_values = []
+        self.increments = []
+        self.observations = []
+
+    def set(self, value):
+        self.set_values.append(value)
+
+    def inc(self, value=1):
+        self.increments.append(value)
+
+    def observe(self, value):
+        self.observations.append(value)
+
+
+class _EventMetricSpy:
+    def labels(self, **_labels):
+        return self
+
+    def inc(self, _value=1):
+        return None
+
+
+class _DummyWebSocket:
+    def __init__(self):
+        self.accepted = False
+        self.messages = []
+
+    async def accept(self):
+        self.accepted = True
+
+    async def send_bytes(self, message):
+        self.messages.append(message)
+
+
+class _EmptyRedis:
+    def get(self, _key):
+        return None
+
+
+class _DummyCelery:
+    def send_task(self, *_args, **_kwargs):
+        return None
+
+
+class _StopPubSub(Exception):
+    pass
+
+
+class _SingleMessagePubSub:
+    def __init__(self, data):
+        self._message = {"type": "message", "data": data}
+
+    def get_message(self):
+        if self._message is None:
+            raise _StopPubSub
+        message = self._message
+        self._message = None
+        return message
+
+
+class _BroadcastManagerSpy:
+    def __init__(self):
+        self.calls = []
+
+    async def broadcast_player_data(self, message, player_id, **kwargs):
+        self.calls.append((message, player_id, kwargs))
+
+
+class _ValueRedis:
+    def __init__(self, value):
+        self.value = value
+
+    def get(self, _key):
+        return self.value
+
+
+def _load_connections(monkeypatch):
+    monkeypatch.setenv("DB_HOST", "localhost")
+    monkeypatch.setenv("DB_PORT", "5432")
+    monkeypatch.setenv("DB_USER", "user")
+    monkeypatch.setenv("DB_PASSWORD", "pass")
+    monkeypatch.setenv("DB_NAME", "db")
+    monkeypatch.setenv("RANKINGS_DB_NAME", "db")
+    return importlib.import_module("fast_api_app.connections")
+
+
+def test_websocket_metrics_have_no_player_labels():
+    assert prometheus.WEBSOCKET_CONNECTIONS._labelnames == ()
+    assert prometheus.WEBSOCKET_BROADCAST_DURATION._labelnames == ()
+    assert prometheus.WEBSOCKET_BYTES_SENT._labelnames == ()
+    assert prometheus.PUBSUB_BYTES_BROADCAST._labelnames == ()
+
+
+def test_connection_manager_records_aggregate_websocket_metrics(monkeypatch):
+    connections = _load_connections(monkeypatch)
+    connection_gauge = _AggregateMetricSpy()
+    broadcast_duration = _AggregateMetricSpy()
+    bytes_sent = _AggregateMetricSpy()
+    events = _EventMetricSpy()
+
+    monkeypatch.setattr(connections, "metrics_enabled", lambda: True)
+    monkeypatch.setattr(connections, "redis_conn", _EmptyRedis())
+    monkeypatch.setattr(connections, "celery", _DummyCelery())
+    monkeypatch.setattr(connections, "WEBSOCKET_CONNECTIONS", connection_gauge)
+    monkeypatch.setattr(
+        connections, "WEBSOCKET_BROADCAST_DURATION", broadcast_duration
+    )
+    monkeypatch.setattr(connections, "WEBSOCKET_BYTES_SENT", bytes_sent)
+    monkeypatch.setattr(connections, "WEBSOCKET_EVENTS", events)
+
+    first = _DummyWebSocket()
+    second = _DummyWebSocket()
+    third = _DummyWebSocket()
+    manager = connections.ConnectionManager()
+
+    asyncio.run(manager.connect(first, "player-1", "connection-1"))
+    asyncio.run(manager.connect(second, "player-1", "connection-2"))
+    asyncio.run(manager.connect(third, "player-2", "connection-3"))
+
+    assert connection_gauge.set_values == [1, 2, 3]
+
+    payload = b"aggregate websocket metrics"
+    asyncio.run(manager.broadcast_player_data(payload, "player-1"))
+
+    compressed_payload = zlib.compress(payload)
+    assert first.messages == [compressed_payload]
+    assert second.messages == [compressed_payload]
+    assert third.messages == []
+    assert bytes_sent.increments == [len(compressed_payload) * 2]
+    assert len(broadcast_duration.observations) == 1
+    assert broadcast_duration.observations[0] >= 0
+
+    manager.disconnect("player-1", "connection-1")
+    manager.disconnect("player-2", "connection-3")
+    manager.disconnect("player-1", "connection-2")
+
+    assert connection_gauge.set_values == [1, 2, 3, 2, 1, 0]
+
+
+def test_pubsub_chunk_bytes_are_aggregated_without_changing_player_routing(
+    monkeypatch,
+):
+    pubsub_module = importlib.import_module("fast_api_app.pubsub")
+    bytes_broadcast = _AggregateMetricSpy()
+    events = _EventMetricSpy()
+    manager = _BroadcastManagerSpy()
+    cached_payload = b"cached legacy payload"
+    raw_message = json.dumps(
+        {
+            "type": "player_chunk",
+            "player_id": "player-1",
+            "phase": "complete",
+            "key": "player-cache-key",
+        }
+    )
+
+    monkeypatch.setattr(pubsub_module, "metrics_enabled", lambda: True)
+    monkeypatch.setattr(
+        pubsub_module, "PUBSUB_BYTES_BROADCAST", bytes_broadcast
+    )
+    monkeypatch.setattr(pubsub_module, "PUBSUB_EVENTS", events)
+    monkeypatch.setattr(pubsub_module, "connection_manager", manager)
+    monkeypatch.setattr(
+        pubsub_module, "redis_conn", _ValueRedis(cached_payload)
+    )
+
+    with pytest.raises(_StopPubSub):
+        asyncio.run(
+            pubsub_module.process_pubsub_message(
+                _SingleMessagePubSub(raw_message)
+            )
+        )
+
+    assert bytes_broadcast.increments == [len(raw_message), len(cached_payload)]
+    assert manager.calls == [
+        (raw_message, "player-1", {"progressive_only": True}),
+        (cached_payload, "player-1", {"legacy_only": True}),
+    ]
+
+
+def test_pubsub_legacy_bytes_are_aggregated_without_changing_player_routing(
+    monkeypatch,
+):
+    pubsub_module = importlib.import_module("fast_api_app.pubsub")
+    bytes_broadcast = _AggregateMetricSpy()
+    events = _EventMetricSpy()
+    manager = _BroadcastManagerSpy()
+    cached_payload = b"legacy payload"
+    raw_message = json.dumps(
+        {"player_id": "player-2", "key": "player-cache-key"}
+    )
+
+    monkeypatch.setattr(pubsub_module, "metrics_enabled", lambda: True)
+    monkeypatch.setattr(
+        pubsub_module, "PUBSUB_BYTES_BROADCAST", bytes_broadcast
+    )
+    monkeypatch.setattr(pubsub_module, "PUBSUB_EVENTS", events)
+    monkeypatch.setattr(pubsub_module, "connection_manager", manager)
+    monkeypatch.setattr(
+        pubsub_module, "redis_conn", _ValueRedis(cached_payload)
+    )
+
+    with pytest.raises(_StopPubSub):
+        asyncio.run(
+            pubsub_module.process_pubsub_message(
+                _SingleMessagePubSub(raw_message)
+            )
+        )
+
+    assert bytes_broadcast.increments == [len(cached_payload)]
+    assert manager.calls == [(cached_payload, "player-2", {})]


### PR DESCRIPTION
## Motivation

Prometheus does not need SplatTop's per-player aggregation. Using `player_id` as a metric label creates an unbounded number of time series and risks substantial Prometheus memory growth when the FastAPI scrape is reconnected.

## Changes

Remove the `player_id` label from:

- `fastapi_websocket_connections`
- `fastapi_websocket_broadcast_duration_seconds`
- `fastapi_websocket_bytes_total`
- `fastapi_pubsub_bytes_total`

The connection gauge now reports total active connections, while duration and byte metrics aggregate across players.

Metric names, application-level player routing, payloads, cache behavior, and player logging remain unchanged. Existing aggregate Grafana queries remain compatible.

## Validation

- 8 focused websocket, cached-payload, and pubsub tests passed.
- Tests cover chunked and legacy pubsub paths and verify player routing is preserved.
- `git diff --check` passed.

The existing TestClient `/metrics` test hangs during app-fixture startup on clean `origin/main`; it was not counted as passing.

## Rollout dependency

Deploy this application change before reconnecting the Prometheus FastAPI scrape. Otherwise, restoring the scrape against the current application version would recreate high-cardinality per-player series.

Companion GitOps change: [GarzAICluster #402](https://github.com/cesaregarza/GarzAICluster/pull/402)

Linear: [CES-571](https://linear.app/cegarza/issue/CES-571/right-size-pod-resource-reservations-from-metrics-server-data-unstick)