### PR TITLE
Handle Kubernetes Redis service port

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,8 +10,9 @@ DB_NAME=splattop
 RANKINGS_DB_NAME=splattop
 
 # Redis (use `redis` inside Docker/Kubernetes and `localhost` for manual hosts)
-REDIS_HOST=localhost
-REDIS_PORT=6379
+# The SPLATTOP_ prefix avoids Kubernetes' reserved REDIS_PORT service variable.
+SPLATTOP_REDIS_HOST=localhost
+SPLATTOP_REDIS_PORT=6379
 
 # Competition Discord auth
 # Optional unless you want Discord login enabled on comp.splat.top or comp.localhost.

--- a/src/shared_lib/constants.py
+++ b/src/shared_lib/constants.py
@@ -26,7 +26,9 @@ REGIONS = [
 
 
 def _redis_port_from_env() -> int:
-    """Resolve Redis's port without mistaking a Kubernetes service URL for it."""
+    """Resolve Redis's port without mistaking a Kubernetes service URL
+    for a numeric port.
+    """
     explicit_port = os.getenv("SPLATTOP_REDIS_PORT")
     if explicit_port:
         return _parse_redis_port(explicit_port)

--- a/src/shared_lib/constants.py
+++ b/src/shared_lib/constants.py
@@ -1,4 +1,5 @@
 import os
+from urllib.parse import urlparse
 
 from dotenv import load_dotenv
 
@@ -22,8 +23,40 @@ REGIONS = [
     "Tentatek",
     "Takoroka",
 ]
-REDIS_PORT = int(os.getenv("REDIS_PORT", "6379"))
-REDIS_HOST = os.getenv("REDIS_HOST", "redis")
+
+
+def _redis_port_from_env() -> int:
+    """Resolve Redis's port without mistaking a Kubernetes service URL for it."""
+    explicit_port = os.getenv("SPLATTOP_REDIS_PORT")
+    if explicit_port:
+        return _parse_redis_port(explicit_port)
+
+    legacy_port = os.getenv("REDIS_PORT")
+    if legacy_port:
+        try:
+            return int(legacy_port)
+        except ValueError:
+            pass
+
+    return _parse_redis_port(
+        os.getenv("REDIS_SERVICE_PORT") or legacy_port or "6379"
+    )
+
+
+def _parse_redis_port(raw_port: str) -> int:
+    try:
+        return int(raw_port)
+    except ValueError:
+        parsed_port = urlparse(raw_port).port
+        if parsed_port is None:
+            raise ValueError(f"Invalid Redis port: {raw_port!r}") from None
+        return parsed_port
+
+
+REDIS_PORT = _redis_port_from_env()
+REDIS_HOST = (
+    os.getenv("SPLATTOP_REDIS_HOST") or os.getenv("REDIS_HOST") or "redis"
+)
 REDIS_URI = f"redis://{REDIS_HOST}:{REDIS_PORT}"
 PLAYER_PUBSUB_CHANNEL = "player_data_channel"
 PLAYER_LATEST_REDIS_KEY = "player_latest_data_v2"

--- a/tests/shared_lib/test_constants.py
+++ b/tests/shared_lib/test_constants.py
@@ -1,0 +1,25 @@
+from shared_lib.constants import _redis_port_from_env
+
+
+def test_redis_port_uses_kubernetes_service_port(monkeypatch):
+    monkeypatch.delenv("SPLATTOP_REDIS_PORT", raising=False)
+    monkeypatch.setenv("REDIS_SERVICE_PORT", "6379")
+    monkeypatch.setenv("REDIS_PORT", "tcp://10.245.248.113:6379")
+
+    assert _redis_port_from_env() == 6379
+
+
+def test_redis_port_accepts_kubernetes_service_url_fallback(monkeypatch):
+    monkeypatch.delenv("SPLATTOP_REDIS_PORT", raising=False)
+    monkeypatch.delenv("REDIS_SERVICE_PORT", raising=False)
+    monkeypatch.setenv("REDIS_PORT", "tcp://10.245.248.113:6380")
+
+    assert _redis_port_from_env() == 6380
+
+
+def test_numeric_legacy_port_overrides_kubernetes_service_port(monkeypatch):
+    monkeypatch.delenv("SPLATTOP_REDIS_PORT", raising=False)
+    monkeypatch.setenv("REDIS_SERVICE_PORT", "6379")
+    monkeypatch.setenv("REDIS_PORT", "6380")
+
+    assert _redis_port_from_env() == 6380

--- a/tests/shared_lib/test_constants.py
+++ b/tests/shared_lib/test_constants.py
@@ -1,6 +1,14 @@
 from shared_lib.constants import _redis_port_from_env
 
 
+def test_explicit_redis_port_override_wins(monkeypatch):
+    monkeypatch.setenv("SPLATTOP_REDIS_PORT", "6381")
+    monkeypatch.setenv("REDIS_SERVICE_PORT", "6379")
+    monkeypatch.setenv("REDIS_PORT", "6380")
+
+    assert _redis_port_from_env() == 6381
+
+
 def test_redis_port_uses_kubernetes_service_port(monkeypatch):
     monkeypatch.delenv("SPLATTOP_REDIS_PORT", raising=False)
     monkeypatch.setenv("REDIS_SERVICE_PORT", "6379")
@@ -23,3 +31,11 @@ def test_numeric_legacy_port_overrides_kubernetes_service_port(monkeypatch):
     monkeypatch.setenv("REDIS_PORT", "6380")
 
     assert _redis_port_from_env() == 6380
+
+
+def test_redis_port_defaults_when_environment_is_unset(monkeypatch):
+    monkeypatch.delenv("SPLATTOP_REDIS_PORT", raising=False)
+    monkeypatch.delenv("REDIS_SERVICE_PORT", raising=False)
+    monkeypatch.delenv("REDIS_PORT", raising=False)
+
+    assert _redis_port_from_env() == 6379


### PR DESCRIPTION
## What changed

- Resolves Redis's port from the application-specific override first, then a numeric legacy `REDIS_PORT`, then Kubernetes' numeric `REDIS_SERVICE_PORT`.
- Safely parses a URL-shaped legacy `REDIS_PORT` when no numeric service variable is available.
- Documents collision-free `SPLATTOP_REDIS_HOST` / `SPLATTOP_REDIS_PORT` overrides.
- Adds regression coverage for the real Kubernetes service-link variables and legacy override behavior.

## Root cause

Kubernetes injects both `REDIS_SERVICE_PORT=6379` and `REDIS_PORT=tcp://<service-ip>:6379` for the Service named `redis`. The dependency refresh parsed `REDIS_PORT` directly as an integer, so FastAPI and Celery exited during import.

The first v2.0.31 rollout exposed this and was immediately rolled back to the recorded healthy images: FastAPI/Celery v2.0.30 and React v2.0.28.

## Impact

This restores backend startup under Kubernetes without changing the Redis address or protocol. Local and legacy numeric `REDIS_PORT` configuration remains supported, while new deployments can use the collision-free `SPLATTOP_REDIS_*` names.

## Validation

- Confirmed the live pod variables are `REDIS_SERVICE_PORT=6379` and `REDIS_PORT=tcp://10.245.248.113:6379`
- Focused regression + startup + native WebSocket tests: 7/7 passed
- FastAPI production image built and imported successfully with the live variable shapes, resolving `REDIS_PORT=6379`
- Celery production image built and imported successfully with the live variable shapes, resolving `REDIS_PORT=6379`
- `git diff --check` and isort check passed
