### PR TITLE
Fix player WebSocket payload decoding

### DIFF
--- a/src/react_app/src/components/player_components/playerPayloadCodec.js
+++ b/src/react_app/src/components/player_components/playerPayloadCodec.js
@@ -1,0 +1,6 @@
+import { inflate } from "pako";
+
+const decodeCompressedPlayerPayload = (compressedPayload) =>
+  JSON.parse(inflate(compressedPayload, { toText: true }));
+
+export { decodeCompressedPlayerPayload };

--- a/src/react_app/src/components/player_components/playerPayloadCodec.test.js
+++ b/src/react_app/src/components/player_components/playerPayloadCodec.test.js
@@ -1,0 +1,24 @@
+import { deflate } from "pako";
+import { decodeCompressedPlayerPayload } from "./playerPayloadCodec";
+
+describe("decodeCompressedPlayerPayload", () => {
+  it("decodes the binary WebSocket payload as UTF-8 JSON", () => {
+    const payload = {
+      player_data: [{ splashtag: "イカ#1234" }],
+      aggregated_data: {
+        weapon_counts: [],
+        weapon_winrate: [],
+        season_results: [],
+        aggregate_season_data: [],
+        latest_data: [],
+      },
+    };
+    const compressed = deflate(JSON.stringify(payload));
+    const arrayBuffer = compressed.buffer.slice(
+      compressed.byteOffset,
+      compressed.byteOffset + compressed.byteLength
+    );
+
+    expect(decodeCompressedPlayerPayload(arrayBuffer)).toEqual(payload);
+  });
+});

--- a/src/react_app/src/components/player_detail.jsx
+++ b/src/react_app/src/components/player_detail.jsx
@@ -3,7 +3,6 @@ import { useParams } from "react-router";
 import Loading from "./misc_components/loading";
 import { modes } from "./constants";
 import { getBaseApiUrl, getBaseWebsocketUrl } from "./utils";
-import { inflate } from "pako";
 import { useTranslation } from "react-i18next";
 import { fetchJson } from "../http";
 import {
@@ -14,6 +13,9 @@ import {
   createPlayerDetailStreamState,
   reducePlayerDetailStreamState,
 } from "./player_components/playerDataUtils";
+import {
+  decodeCompressedPlayerPayload,
+} from "./player_components/playerPayloadCodec";
 
 const ChartController = React.lazy(() =>
   import("./player_components/chart_controller")
@@ -84,10 +86,7 @@ const PlayerDetailContent = () => {
           if (event.data instanceof Blob) {
             const reader = new FileReader();
             reader.onload = () => {
-              const decompressedData = inflate(reader.result, {
-                to: "string",
-              });
-              const newData = JSON.parse(decompressedData);
+              const newData = decodeCompressedPlayerPayload(reader.result);
               applySocketPayload(newData);
             };
             reader.readAsArrayBuffer(event.data);


### PR DESCRIPTION
## Summary

- decode compressed player WebSocket frames with pako 3's `toText` option
- isolate the binary-to-JSON conversion in a small codec helper
- add a regression test using an actual deflated UTF-8 player payload and an `ArrayBuffer`

## Root cause

The dependency refresh upgraded pako from 2.1.0 to 3.0.1, but the player page still called `inflate(..., { to: "string" })`. Pako 3 ignores that removed option and returns a `Uint8Array`; `JSON.parse` then receives comma-separated byte values and throws. REST and WebSocket transport remain healthy, but the season results and chart stay in their loading states.

## Validation

- exact Node 24.15.0 / npm 12.0.2 frontend CI sequence
- `npm audit --audit-level=high`: zero vulnerabilities
- Jest: 32 suites and 103 tests passed
- Vite production build passed
- React Doctor changed-scope scan: 87/100, with one pre-existing async-effect warning
- production React Dockerfile build passed
- headless Chromium against the built image received the live 89,619-byte WebSocket frame and rendered the complete player results and chart without page or request errors
