### PR TITLE
Fix Fresh 2026 player season results

### DIFF
--- a/src/react_app/src/components/player_components/achievements.test.js
+++ b/src/react_app/src/components/player_components/achievements.test.js
@@ -54,37 +54,37 @@ describe("Achievements", () => {
           aggregated_data: {
             season_results: [
               {
-                season_number: 8,
+                season_number: 7,
                 region: true,
                 mode: "Splat Zones",
                 rank: 1,
               },
               {
-                season_number: 8,
+                season_number: 7,
                 region: true,
                 mode: "Tower Control",
                 rank: 21,
               },
               {
-                season_number: 7,
+                season_number: 6,
                 region: false,
                 mode: "Splat Zones",
                 rank: 5,
               },
               {
-                season_number: 7,
+                season_number: 6,
                 region: false,
                 mode: "Tower Control",
                 rank: 7,
               },
               {
-                season_number: 7,
+                season_number: 6,
                 region: false,
                 mode: "Rainmaker",
                 rank: 8,
               },
               {
-                season_number: 7,
+                season_number: 6,
                 region: false,
                 mode: "Clam Blitz",
                 rank: 9,
@@ -126,7 +126,7 @@ describe("Achievements", () => {
           aggregated_data: {
             season_results: [
               {
-                season_number: 8,
+                season_number: 7,
                 mode: "Splat Zones",
                 rank: 1,
               },

--- a/src/react_app/src/components/player_components/playerPageUtils.js
+++ b/src/react_app/src/components/player_components/playerPageUtils.js
@@ -45,16 +45,21 @@ const getDisplaySeasonNumber = (rawSeasonNumber) =>
 const getRawSeasonNumber = (displaySeasonNumber) =>
   isFiniteNumber(displaySeasonNumber) ? displaySeasonNumber - 1 : null;
 
+const toDisplaySeasonRow = (item) => ({
+  ...item,
+  season_number: getDisplaySeasonNumber(item.season_number),
+});
+
+const getHistoricalSeasonRows = (seasonResults = []) =>
+  seasonResults.map(toDisplaySeasonRow);
+
 const getLatestSeasonRows = (latestData = []) =>
   latestData
     .filter(
       (item, index, collection) =>
         index === collection.findIndex((candidate) => candidate.mode === item.mode)
     )
-    .map((item) => ({
-      ...item,
-      season_number: getDisplaySeasonNumber(item.season_number),
-    }));
+    .map(toDisplaySeasonRow);
 
 const sortAliasesByLastSeen = (aliases = []) =>
   [...aliases].sort(
@@ -84,7 +89,10 @@ const getCombinedSeasonResults = (aggregatedData = {}) => {
     ? aggregatedData.latest_data
     : [];
 
-  return [...activeData, ...getLatestSeasonRows(latestData)];
+  return [
+    ...getHistoricalSeasonRows(activeData),
+    ...getLatestSeasonRows(latestData),
+  ];
 };
 
 const getAvailableSeasonResultTabs = (aggregatedData = {}) =>
@@ -357,7 +365,9 @@ const getHistoryRegionsByDisplaySeason = (chartData = {}) => {
 const getHistoricalSeasonResults = (chartData = {}) => {
   const historyRegions = getHistoryRegionsByDisplaySeason(chartData);
 
-  return (chartData.aggregated_data?.season_results || []).map((row) => ({
+  return getHistoricalSeasonRows(
+    chartData.aggregated_data?.season_results || []
+  ).map((row) => ({
     ...row,
     region: historyRegions.get(row.season_number) ?? row.region ?? null,
   }));

--- a/src/react_app/src/components/player_components/playerPageUtils.test.js
+++ b/src/react_app/src/components/player_components/playerPageUtils.test.js
@@ -1,6 +1,8 @@
 import {
   countDiamondSeasons,
+  getAvailableDisplaySeasons,
   getCareerHighlights,
+  getCombinedSeasonResults,
   getDefaultPlayerMode,
   getDefaultSeasonResultTab,
   getDefaultSelectedDisplaySeason,
@@ -20,13 +22,84 @@ describe("playerPageUtils", () => {
   it("defaults season results to the newest available season", () => {
     const aggregatedData = {
       season_results: [
-        { season_number: 8, mode: "Splat Zones" },
-        { season_number: 10, mode: "Rainmaker" },
+        { season_number: 7, mode: "Splat Zones" },
+        { season_number: 9, mode: "Rainmaker" },
       ],
       latest_data: [],
     };
 
     expect(getDefaultSeasonResultTab(aggregatedData)).toBe(10);
+  });
+
+  it("normalizes Fresh 2026 results and live data to display seasons", () => {
+    const historicalResult = {
+      season_number: 14,
+      mode: "Splat Zones",
+      rank: 55,
+      x_power: 2850,
+    };
+    const chartData = {
+      player_data: [
+        {
+          season_number: 14,
+          mode: "Splat Zones",
+          timestamp: "2026-03-01T03:20:22.000Z",
+          x_power: 2800,
+        },
+        {
+          season_number: 14,
+          mode: "Splat Zones",
+          timestamp: "2026-05-31T22:14:00.000Z",
+          x_power: 2850,
+        },
+      ],
+      aggregated_data: {
+        season_results: [historicalResult],
+        latest_data: [
+          {
+            season_number: 15,
+            mode: "Splat Zones",
+            rank: 1,
+            x_power: 4056.3,
+          },
+        ],
+        aggregate_season_data: [
+          {
+            season_number: 14,
+            mode: "Splat Zones",
+            peak_x_power: 3123.1,
+          },
+        ],
+      },
+    };
+
+    const combinedResults = getCombinedSeasonResults(chartData.aggregated_data);
+
+    expect(combinedResults).toEqual([
+      expect.objectContaining({ season_number: 15, rank: 55 }),
+      expect.objectContaining({ season_number: 16, rank: 1 }),
+    ]);
+    expect(getAvailableDisplaySeasons(chartData)).toEqual([16, 15]);
+    expect(getModeAnalysisSummary(chartData, "Splat Zones", 15)).toEqual(
+      expect.objectContaining({ rank: 55, peakXp: 3123.1 })
+    );
+    expect(getSeasonArchiveRows(chartData, "Splat Zones")).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          season_number: 15,
+          raw_season_number: 14,
+          finishRank: 55,
+          peakXp: 3123.1,
+        }),
+      ])
+    );
+    expect(combinedResults[0]).not.toBe(historicalResult);
+    expect(historicalResult).toEqual({
+      season_number: 14,
+      mode: "Splat Zones",
+      rank: 55,
+      x_power: 2850,
+    });
   });
 
   it("defaults the selected display season to the newest season for the selected mode", () => {
@@ -97,11 +170,11 @@ describe("playerPageUtils", () => {
       ],
       aggregated_data: {
         season_results: [
-          { season_number: 8, mode: "Splat Zones", rank: 1, region: true },
-          { season_number: 8, mode: "Tower Control", rank: 21, region: true },
-          { season_number: 7, mode: "Rainmaker", rank: 430, region: false },
-          { season_number: 6, mode: "Clam Blitz", rank: 12, region: false },
-          { season_number: 6, mode: "Splat Zones", rank: 700, region: false },
+          { season_number: 7, mode: "Splat Zones", rank: 1, region: true },
+          { season_number: 7, mode: "Tower Control", rank: 21, region: true },
+          { season_number: 6, mode: "Rainmaker", rank: 430, region: false },
+          { season_number: 5, mode: "Clam Blitz", rank: 12, region: false },
+          { season_number: 5, mode: "Splat Zones", rank: 700, region: false },
         ],
       },
     };
@@ -164,7 +237,7 @@ describe("playerPageUtils", () => {
       ],
       aggregated_data: {
         season_results: [
-          { season_number: 5, mode: "Rainmaker", rank: 8, region: true },
+          { season_number: 4, mode: "Rainmaker", rank: 8, region: true },
         ],
         latest_data: [{ season_number: 5, mode: "Rainmaker", rank: 4, region: false }],
         aggregate_season_data: [

--- a/src/react_app/src/components/player_components/season_archive.test.js
+++ b/src/react_app/src/components/player_components/season_archive.test.js
@@ -102,37 +102,37 @@ describe("SeasonArchive", () => {
           aggregated_data: {
             season_results: [
               {
-                season_number: 10,
+                season_number: 9,
                 region: true,
                 mode: "Rainmaker",
                 rank: 4,
               },
               {
-                season_number: 9,
+                season_number: 8,
                 region: false,
                 mode: "Rainmaker",
                 rank: 12,
               },
               {
-                season_number: 8,
+                season_number: 7,
                 region: false,
                 mode: "Rainmaker",
                 rank: 18,
               },
               {
-                season_number: 7,
+                season_number: 6,
                 region: true,
                 mode: "Rainmaker",
                 rank: 31,
               },
               {
-                season_number: 6,
+                season_number: 5,
                 region: true,
                 mode: "Rainmaker",
                 rank: 48,
               },
               {
-                season_number: 5,
+                season_number: 4,
                 region: false,
                 mode: "Splat Zones",
                 rank: 12,

--- a/src/react_app/src/components/player_components/season_results.test.js
+++ b/src/react_app/src/components/player_components/season_results.test.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import SeasonResults from "./season_results";
 
 jest.mock("chroma-js", () => ({
@@ -62,11 +62,11 @@ describe("SeasonResults", () => {
             aggregate_season_data: [],
             latest_data: [],
             season_results: [
-              { season_number: 6, mode: "Rainmaker", rank: 1, x_power: 3000 },
-              { season_number: 5, mode: "Rainmaker", rank: 2, x_power: 2900 },
-              { season_number: 4, mode: "Rainmaker", rank: 3, x_power: 2800 },
-              { season_number: 3, mode: "Rainmaker", rank: 4, x_power: 2700 },
-              { season_number: 2, mode: "Rainmaker", rank: 5, x_power: 2600 },
+              { season_number: 5, mode: "Rainmaker", rank: 1, x_power: 3000 },
+              { season_number: 4, mode: "Rainmaker", rank: 2, x_power: 2900 },
+              { season_number: 3, mode: "Rainmaker", rank: 3, x_power: 2800 },
+              { season_number: 2, mode: "Rainmaker", rank: 4, x_power: 2700 },
+              { season_number: 1, mode: "Rainmaker", rank: 5, x_power: 2600 },
             ],
           },
         }}
@@ -103,7 +103,7 @@ describe("SeasonResults", () => {
             aggregate_season_data: [],
             latest_data: [],
             season_results: [
-              { season_number: 6, mode: "Rainmaker", rank: 1, x_power: 3000 },
+              { season_number: 5, mode: "Rainmaker", rank: 1, x_power: 3000 },
             ],
           },
         }}
@@ -116,5 +116,65 @@ describe("SeasonResults", () => {
     expect(onSeasonChange).not.toHaveBeenCalled();
     expect(screen.getByRole("button", { name: /Season 6/i })).toBeInTheDocument();
     expect(screen.getAllByText("--").length).toBeGreaterThan(0);
+  });
+
+  it("loads finalized Fresh 2026 rows when switching from Sizzle", () => {
+    render(
+      <SeasonResults
+        data={{
+          player_data: [
+            {
+              season_number: 14,
+              mode: "Splat Zones",
+              timestamp: "2026-05-31T22:14:00.000Z",
+              x_power: 2850,
+            },
+          ],
+          aggregated_data: {
+            weapon_counts: [
+              {
+                season_number: 14,
+                mode: "Splat Zones",
+                weapon_id: 1101,
+                count: 20,
+              },
+            ],
+            aggregate_season_data: [
+              {
+                season_number: 14,
+                mode: "Splat Zones",
+                peak_x_power: 3123.1,
+              },
+            ],
+            latest_data: [
+              {
+                season_number: 15,
+                mode: "Splat Zones",
+                rank: 1,
+                x_power: 4056.3,
+              },
+            ],
+            season_results: [
+              {
+                season_number: 14,
+                mode: "Splat Zones",
+                rank: 55,
+                x_power: 2850,
+                weapon_id: 1101,
+              },
+            ],
+          },
+        }}
+        weaponReferenceData={null}
+      />
+    );
+
+    expect(screen.getByText("4056.3")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /Season 14/i }));
+
+    expect(screen.getByText("55")).toBeInTheDocument();
+    expect(screen.getByText("2850.0")).toBeInTheDocument();
+    expect(screen.getByText("3123.1")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## What changed

- normalize finalized `season_results` rows from API/raw season numbers to UI/display season numbers at the shared player-page boundary
- reuse that normalized historical data for season results, archive, analysis, achievements, and region joins
- add a Fresh 2026 regression that starts on Sizzle and switches to Fresh

## Why

The API correctly returned Fresh 2026 as raw season `14`, while the player UI selects Fresh using display season `15`. Current-season rows were already converted, but finalized historical rows were not, so the Fresh table filtered out all four valid results and rendered placeholders.

## User impact

Fresh 2026 now shows finalized rank, final XP, peak XP, and weapon data on player pages. Historical archive and career summaries use the same season mapping.

## Validation

- `npm run test:ci` on Node 24.15.0: 32 suites / 105 tests passed
- `npm run build` on Node 24.15.0: passed
- production-equivalent React image build: passed
- local built image exercised against production REST/WebSocket data: Fresh 2026 populated all four mode rows with zero browser or request errors
