### PR TITLE
Restore Fresh 2026 weapon peak rows

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -124,6 +124,7 @@ jobs:
           uv run --frozen pytest -p no:cacheprovider
           tests/test_app_startup.py
           tests/test_player_websocket.py
+          tests/celery/test_weapon_leaderboard.py
 
   frontend:
     name: Frontend lock, audit, tests, and build

--- a/src/celery_app/tasks/leaderboard.py
+++ b/src/celery_app/tasks/leaderboard.py
@@ -25,6 +25,7 @@ from shared_lib.utils import get_all_alt_kits
 
 logger = logging.getLogger(__name__)
 
+FIRST_WEAPON_LEADERBOARD_SEASON = 1
 idx_columns = ["player_id", "season_number", "mode", "region"]
 
 
@@ -35,66 +36,21 @@ def _empty_weapon_leaderboard() -> pd.DataFrame:
             "weapon_id",
             "max_x_power",
             "games_played",
-            "total_games_played",
             "percent_games_played",
         ]
     ).set_index(idx_columns)
 
 
-def fetch_past_weapon_leaderboard_data() -> pd.DataFrame:
-    """Fetches past weapon leaderboard data from the database.
-
-    Returns:
-        pd.DataFrame: A DataFrame of weapon leaderboard data.
-    """
-    logger.info("Fetching past weapon leaderboard data")
-    query = text(WEAPON_LEADERBOARD_QUERY)
-    start = perf_counter()
-    with Session() as session:
-        result = session.execute(query).fetchall()
-        weapon_leaderboard = pd.DataFrame(
-            [{**row._asdict()} for row in result]
-        ).set_index(idx_columns)
-    if metrics_enabled():
-        DATA_PULL_DURATION.labels(
-            task="celery.weapon_leaderboard.past"
-        ).observe(perf_counter() - start)
-        DATA_PULL_ROWS.labels(task="celery.weapon_leaderboard.past").set(
-            len(weapon_leaderboard)
-        )
-
-    return weapon_leaderboard
-
-
-def fetch_live_weapon_leaderboard_data() -> pd.DataFrame:
-    """Fetches live weapon leaderboard data from the database.
-
-    Returns:
-        pd.DataFrame: A DataFrame of weapon leaderboard data.
-    """
-    logger.info("Fetching live weapon leaderboard data")
-    query = text(LIVE_WEAPON_LEADERBOARD_QUERY)
-    start = perf_counter()
-    with Session() as session:
-        current_season = fetch_current_season(session)
-    if current_season is None:
+def _aggregate_weapon_rows(
+    rows: list[dict], alt_kits: dict[str, str]
+) -> pd.DataFrame:
+    if not rows:
         return _empty_weapon_leaderboard()
-    with Session() as session:
-        result = session.execute(
-            query, {"season_number": current_season}
-        ).fetchall()
-        rows = [{**row._asdict()} for row in result]
-        if not rows:
-            weapon_leaderboard = _empty_weapon_leaderboard()
-        else:
-            weapon_leaderboard = pd.DataFrame(rows).set_index(idx_columns)
 
+    weapon_leaderboard = pd.DataFrame(rows).set_index(idx_columns)
+    weapon_ids = weapon_leaderboard["weapon_id"].astype(str)
     weapon_leaderboard["weapon_id"] = (
-        weapon_leaderboard["weapon_id"]
-        .astype(str)
-        .map(get_all_alt_kits())
-        .fillna(weapon_leaderboard["weapon_id"])
-        .astype(str)
+        weapon_ids.map(alt_kits).fillna(weapon_ids).astype(str)
     )
 
     total_games_df = (
@@ -110,7 +66,7 @@ def fetch_live_weapon_leaderboard_data() -> pd.DataFrame:
         "games_played"
     ].div(weapon_leaderboard["total_games_played"])
 
-    weapon_leaderboard = (
+    return (
         weapon_leaderboard.groupby(idx_columns + ["weapon_id"])
         .agg(
             {
@@ -121,6 +77,98 @@ def fetch_live_weapon_leaderboard_data() -> pd.DataFrame:
         )
         .reset_index()
         .set_index(idx_columns)
+    )
+
+
+def _completed_seasons_to_derive(
+    archived_seasons: set[int],
+    current_season: int,
+) -> list[int]:
+    seasons = set(_archive_gap_seasons(archived_seasons, current_season))
+    previous_season = current_season - 1
+    if previous_season >= FIRST_WEAPON_LEADERBOARD_SEASON:
+        # Rebuild the latest completed season during archive handoff so a
+        # partially published archive cannot hide the remaining rows.
+        seasons.add(previous_season)
+    return sorted(seasons)
+
+
+def _archive_gap_seasons(
+    archived_seasons: set[int], current_season: int
+) -> list[int]:
+    return sorted(
+        set(range(FIRST_WEAPON_LEADERBOARD_SEASON, current_season))
+        - archived_seasons
+    )
+
+
+def _combine_weapon_leaderboards(
+    weapon_leaderboards: list[pd.DataFrame],
+) -> pd.DataFrame:
+    populated = [frame for frame in weapon_leaderboards if not frame.empty]
+    if not populated:
+        return _empty_weapon_leaderboard()
+
+    combined = pd.concat(populated).reset_index()
+    combined["_weapon_id_key"] = combined["weapon_id"].astype(str)
+    combined = combined.drop_duplicates(
+        subset=idx_columns + ["_weapon_id_key"], keep="first"
+    ).drop(columns="_weapon_id_key")
+    return combined.set_index(idx_columns).sort_index()
+
+
+def fetch_past_weapon_leaderboard_data() -> pd.DataFrame:
+    """Fetches past weapon leaderboard data from the database.
+
+    Returns:
+        pd.DataFrame: A DataFrame of weapon leaderboard data.
+    """
+    logger.info("Fetching past weapon leaderboard data")
+    query = text(WEAPON_LEADERBOARD_QUERY)
+    start = perf_counter()
+    with Session() as session:
+        result = session.execute(query).fetchall()
+        rows = [{**row._asdict()} for row in result]
+        weapon_leaderboard = (
+            pd.DataFrame(rows).set_index(idx_columns)
+            if rows
+            else _empty_weapon_leaderboard()
+        )
+    if metrics_enabled():
+        DATA_PULL_DURATION.labels(
+            task="celery.weapon_leaderboard.past"
+        ).observe(perf_counter() - start)
+        DATA_PULL_ROWS.labels(task="celery.weapon_leaderboard.past").set(
+            len(weapon_leaderboard)
+        )
+
+    return weapon_leaderboard
+
+
+def fetch_live_weapon_leaderboard_data(
+    current_season: int | None = None,
+    alt_kits: dict[str, str] | None = None,
+) -> pd.DataFrame:
+    """Fetches live weapon leaderboard data from the database.
+
+    Returns:
+        pd.DataFrame: A DataFrame of weapon leaderboard data.
+    """
+    logger.info("Fetching live weapon leaderboard data")
+    query = text(LIVE_WEAPON_LEADERBOARD_QUERY)
+    start = perf_counter()
+    if current_season is None:
+        with Session() as session:
+            current_season = fetch_current_season(session)
+    if current_season is None:
+        return _empty_weapon_leaderboard()
+    with Session() as session:
+        result = session.execute(
+            query, {"season_number": current_season}
+        ).fetchall()
+        rows = [{**row._asdict()} for row in result]
+    weapon_leaderboard = _aggregate_weapon_rows(
+        rows, alt_kits if alt_kits is not None else get_all_alt_kits()
     )
     if metrics_enabled():
         DATA_PULL_DURATION.labels(
@@ -133,15 +181,91 @@ def fetch_live_weapon_leaderboard_data() -> pd.DataFrame:
     return weapon_leaderboard
 
 
+def fetch_completed_weapon_leaderboard_fallback_data(
+    archived_seasons: set[int],
+    current_season: int | None,
+    alt_kits: dict[str, str] | None = None,
+) -> pd.DataFrame:
+    """Derive archive gaps and the latest completed rollover season."""
+    if current_season is None:
+        return _empty_weapon_leaderboard()
+
+    logger.info("Checking completed weapon leaderboard fallback seasons")
+    start = perf_counter()
+    leaderboard_query = text(LIVE_WEAPON_LEADERBOARD_QUERY)
+    fallback_seasons = _completed_seasons_to_derive(
+        archived_seasons, current_season
+    )
+    with Session() as session:
+        rows = []
+        for season_number in fallback_seasons:
+            season_rows = session.execute(
+                leaderboard_query, {"season_number": season_number}
+            ).fetchall()
+            rows.extend({**row._asdict()} for row in season_rows)
+
+    archive_gaps = _archive_gap_seasons(archived_seasons, current_season)
+    if archive_gaps:
+        logger.warning(
+            "Deriving missing completed weapon leaderboard seasons: %s",
+            ", ".join(str(season) for season in archive_gaps),
+        )
+    elif fallback_seasons:
+        logger.info(
+            "Rebuilding latest completed weapon leaderboard season: %s",
+            fallback_seasons[-1],
+        )
+    weapon_leaderboard = _aggregate_weapon_rows(
+        rows, alt_kits if alt_kits is not None else get_all_alt_kits()
+    )
+    if metrics_enabled():
+        DATA_PULL_DURATION.labels(
+            task="celery.weapon_leaderboard.completed_fallback"
+        ).observe(perf_counter() - start)
+        DATA_PULL_ROWS.labels(
+            task="celery.weapon_leaderboard.completed_fallback"
+        ).set(len(weapon_leaderboard))
+
+    return weapon_leaderboard
+
+
 def fetch_weapon_leaderboard() -> pd.DataFrame:
     logger.info("Fetching weapon data")
     start = perf_counter()
     past_weapon_leaderboard = fetch_past_weapon_leaderboard_data()
-    live_weapon_leaderboard = fetch_live_weapon_leaderboard_data()
-    weapon_leaderboard = pd.concat(
-        [past_weapon_leaderboard, live_weapon_leaderboard]
-    ).sort_index()
-    del past_weapon_leaderboard, live_weapon_leaderboard
+    archived_seasons = (
+        set(
+            past_weapon_leaderboard.reset_index()["season_number"]
+            .dropna()
+            .astype(int)
+            .unique()
+        )
+        if not past_weapon_leaderboard.empty
+        else set()
+    )
+    with Session() as session:
+        current_season = fetch_current_season(session)
+    alt_kits = get_all_alt_kits()
+    completed_weapon_leaderboard_fallback = (
+        fetch_completed_weapon_leaderboard_fallback_data(
+            archived_seasons, current_season, alt_kits
+        )
+    )
+    live_weapon_leaderboard = fetch_live_weapon_leaderboard_data(
+        current_season, alt_kits
+    )
+    weapon_leaderboard = _combine_weapon_leaderboards(
+        [
+            past_weapon_leaderboard,
+            completed_weapon_leaderboard_fallback,
+            live_weapon_leaderboard,
+        ]
+    )
+    del (
+        past_weapon_leaderboard,
+        completed_weapon_leaderboard_fallback,
+        live_weapon_leaderboard,
+    )
 
     redis_conn.set(
         WEAPON_LEADERBOARD_PEAK_REDIS_KEY,

--- a/src/celery_app/tasks/leaderboard.py
+++ b/src/celery_app/tasks/leaderboard.py
@@ -44,6 +44,7 @@ def _empty_weapon_leaderboard() -> pd.DataFrame:
 def _aggregate_weapon_rows(
     rows: list[dict], alt_kits: dict[str, str]
 ) -> pd.DataFrame:
+    """Normalize weapon kits and calculate per-player usage shares."""
     if not rows:
         return _empty_weapon_leaderboard()
 
@@ -84,6 +85,7 @@ def _completed_seasons_to_derive(
     archived_seasons: set[int],
     current_season: int,
 ) -> list[int]:
+    """Return archive gaps plus the latest completed handoff season."""
     seasons = set(_archive_gap_seasons(archived_seasons, current_season))
     previous_season = current_season - 1
     if previous_season >= FIRST_WEAPON_LEADERBOARD_SEASON:
@@ -96,6 +98,7 @@ def _completed_seasons_to_derive(
 def _archive_gap_seasons(
     archived_seasons: set[int], current_season: int
 ) -> list[int]:
+    """Return supported completed seasons absent from the archive."""
     return sorted(
         set(range(FIRST_WEAPON_LEADERBOARD_SEASON, current_season))
         - archived_seasons
@@ -105,6 +108,7 @@ def _archive_gap_seasons(
 def _combine_weapon_leaderboards(
     weapon_leaderboards: list[pd.DataFrame],
 ) -> pd.DataFrame:
+    """Merge archive-first frames and remove exact key collisions."""
     populated = [frame for frame in weapon_leaderboards if not frame.empty]
     if not populated:
         return _empty_weapon_leaderboard()
@@ -229,7 +233,7 @@ def fetch_completed_weapon_leaderboard_fallback_data(
     return weapon_leaderboard
 
 
-def fetch_weapon_leaderboard() -> pd.DataFrame:
+def fetch_weapon_leaderboard() -> None:
     logger.info("Fetching weapon data")
     start = perf_counter()
     past_weapon_leaderboard = fetch_past_weapon_leaderboard_data()

--- a/tests/celery/test_weapon_leaderboard.py
+++ b/tests/celery/test_weapon_leaderboard.py
@@ -76,6 +76,16 @@ def test_latest_completed_season_is_derived_during_archive_handoff():
     ) == [14]
 
 
+def test_no_completed_season_exists_below_supported_floor():
+    assert (
+        leaderboard_mod._completed_seasons_to_derive(
+            archived_seasons=set(),
+            current_season=leaderboard_mod.FIRST_WEAPON_LEADERBOARD_SEASON,
+        )
+        == []
+    )
+
+
 def test_combine_weapon_leaderboards_keeps_archive_on_collision():
     archive = _frame(
         [

--- a/tests/celery/test_weapon_leaderboard.py
+++ b/tests/celery/test_weapon_leaderboard.py
@@ -1,0 +1,344 @@
+import os
+
+import orjson
+import pandas as pd
+import pytest
+
+os.environ.setdefault("DB_HOST", "localhost")
+os.environ.setdefault("DB_PORT", "5432")
+os.environ.setdefault("DB_USER", "user")
+os.environ.setdefault("DB_PASSWORD", "pass")
+os.environ.setdefault("DB_NAME", "db")
+os.environ.setdefault("RANKINGS_DB_NAME", "db")
+
+from celery_app.tasks import leaderboard as leaderboard_mod
+
+
+def _frame(rows):
+    return pd.DataFrame(rows).set_index(leaderboard_mod.idx_columns)
+
+
+def test_aggregate_weapon_rows_normalizes_alt_kits_and_usage():
+    rows = [
+        {
+            "player_id": "p1",
+            "season_number": 14,
+            "mode": "Splat Zones",
+            "region": False,
+            "weapon_id": 40,
+            "max_x_power": 2500.0,
+            "games_played": 6,
+        },
+        {
+            "player_id": "p1",
+            "season_number": 14,
+            "mode": "Splat Zones",
+            "region": False,
+            "weapon_id": 1101,
+            "max_x_power": 2600.0,
+            "games_played": 4,
+        },
+        {
+            "player_id": "p1",
+            "season_number": 14,
+            "mode": "Splat Zones",
+            "region": False,
+            "weapon_id": 50,
+            "max_x_power": 2550.0,
+            "games_played": 10,
+        },
+    ]
+
+    result = leaderboard_mod._aggregate_weapon_rows(
+        rows, {"1101": "40"}
+    ).reset_index()
+
+    canonical = result[result["weapon_id"] == "40"].iloc[0]
+    other = result[result["weapon_id"] == "50"].iloc[0]
+    assert canonical["max_x_power"] == 2600.0
+    assert canonical["games_played"] == 10
+    assert canonical["percent_games_played"] == pytest.approx(0.5)
+    assert other["percent_games_played"] == pytest.approx(0.5)
+    assert result["percent_games_played"].sum() == pytest.approx(1.0)
+
+
+def test_missing_completed_seasons_finds_rollover_gap():
+    assert leaderboard_mod._completed_seasons_to_derive(
+        archived_seasons=set(range(1, 14)),
+        current_season=15,
+    ) == [14]
+
+
+def test_latest_completed_season_is_derived_during_archive_handoff():
+    assert leaderboard_mod._completed_seasons_to_derive(
+        archived_seasons=set(range(1, 15)),
+        current_season=15,
+    ) == [14]
+
+
+def test_combine_weapon_leaderboards_keeps_archive_on_collision():
+    archive = _frame(
+        [
+            {
+                "player_id": "p1",
+                "season_number": 13,
+                "mode": "Splat Zones",
+                "region": False,
+                "weapon_id": 40,
+                "max_x_power": 2500.0,
+                "games_played": 20,
+                "percent_games_played": 1.0,
+            }
+        ]
+    )
+    derived = _frame(
+        [
+            {
+                "player_id": "p1",
+                "season_number": 13,
+                "mode": "Splat Zones",
+                "region": False,
+                "weapon_id": "40",
+                "max_x_power": 9999.0,
+                "games_played": 1,
+                "percent_games_played": 1.0,
+            },
+            {
+                "player_id": "p1",
+                "season_number": 14,
+                "mode": "Splat Zones",
+                "region": False,
+                "weapon_id": "40",
+                "max_x_power": 2600.0,
+                "games_played": 30,
+                "percent_games_played": 1.0,
+            },
+        ]
+    )
+    live = _frame(
+        [
+            {
+                "player_id": "p1",
+                "season_number": 15,
+                "mode": "Splat Zones",
+                "region": False,
+                "weapon_id": "40",
+                "max_x_power": 2700.0,
+                "games_played": 5,
+                "percent_games_played": 1.0,
+            }
+        ]
+    )
+
+    result = leaderboard_mod._combine_weapon_leaderboards(
+        [archive, derived, live]
+    ).reset_index()
+
+    assert result["season_number"].tolist() == [13, 14, 15]
+    assert (
+        result.loc[result["season_number"] == 13, "max_x_power"].item()
+        == 2500.0
+    )
+    assert (
+        not result.assign(weapon_id_key=result["weapon_id"].astype(str))
+        .duplicated(subset=leaderboard_mod.idx_columns + ["weapon_id_key"])
+        .any()
+    )
+
+
+class _FakeRow:
+    def __init__(self, values):
+        self.values = values
+
+    def __getitem__(self, index):
+        return list(self.values.values())[index]
+
+    def _asdict(self):
+        return self.values
+
+
+class _FakeResult:
+    def __init__(self, rows):
+        self.rows = rows
+
+    def fetchall(self):
+        return self.rows
+
+
+class _FakeSession:
+    def __init__(self):
+        self.derived_seasons = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, traceback):
+        return False
+
+    def execute(self, query, params):
+        season_number = params["season_number"]
+        self.derived_seasons.append(season_number)
+        return _FakeResult(
+            [
+                _FakeRow(
+                    {
+                        "player_id": "p1",
+                        "season_number": season_number,
+                        "mode": "Splat Zones",
+                        "region": False,
+                        "weapon_id": 40,
+                        "max_x_power": 2600.0,
+                        "games_played": 10,
+                    }
+                )
+            ]
+        )
+
+
+def test_fetch_missing_completed_rows_only_queries_archive_gap(monkeypatch):
+    session = _FakeSession()
+    monkeypatch.setattr(leaderboard_mod, "Session", lambda: session)
+
+    result = leaderboard_mod.fetch_completed_weapon_leaderboard_fallback_data(
+        archived_seasons=set(range(1, 14)),
+        current_season=15,
+        alt_kits={},
+    ).reset_index()
+
+    assert session.derived_seasons == [14]
+    assert result["season_number"].tolist() == [14]
+    assert result["percent_games_played"].tolist() == [1.0]
+
+
+def test_fetch_weapon_leaderboard_publishes_archive_fallback_and_live(
+    monkeypatch,
+):
+    archive = _frame(
+        [
+            {
+                "player_id": "archived",
+                "season_number": 13,
+                "mode": "Splat Zones",
+                "region": False,
+                "weapon_id": 40,
+                "max_x_power": 2500.0,
+                "games_played": 20,
+                "percent_games_played": 1.0,
+            },
+            {
+                "player_id": "collision",
+                "season_number": 14,
+                "mode": "Splat Zones",
+                "region": False,
+                "weapon_id": 40,
+                "max_x_power": 2600.0,
+                "games_played": 30,
+                "percent_games_played": 1.0,
+            },
+        ]
+    )
+    fallback = _frame(
+        [
+            {
+                "player_id": "collision",
+                "season_number": 14,
+                "mode": "Splat Zones",
+                "region": False,
+                "weapon_id": "40",
+                "max_x_power": 9999.0,
+                "games_played": 1,
+                "percent_games_played": 1.0,
+            },
+            {
+                "player_id": "recovered",
+                "season_number": 14,
+                "mode": "Splat Zones",
+                "region": False,
+                "weapon_id": "40",
+                "max_x_power": 2700.0,
+                "games_played": 40,
+                "percent_games_played": 1.0,
+            },
+        ]
+    )
+    live = _frame(
+        [
+            {
+                "player_id": "live",
+                "season_number": 15,
+                "mode": "Splat Zones",
+                "region": False,
+                "weapon_id": "40",
+                "max_x_power": 2800.0,
+                "games_played": 5,
+                "percent_games_played": 1.0,
+            }
+        ]
+    )
+    calls = {}
+
+    class _CurrentSeasonSession:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, traceback):
+            return False
+
+    class _Redis:
+        def __init__(self):
+            self.values = {}
+
+        def set(self, key, value):
+            self.values[key] = value
+
+    redis = _Redis()
+
+    def fetch_fallback(archived_seasons, current_season, alt_kits):
+        calls["fallback"] = (archived_seasons, current_season, alt_kits)
+        return fallback
+
+    def fetch_live(current_season, alt_kits):
+        calls["live"] = (current_season, alt_kits)
+        return live
+
+    monkeypatch.setattr(
+        leaderboard_mod, "fetch_past_weapon_leaderboard_data", lambda: archive
+    )
+    monkeypatch.setattr(
+        leaderboard_mod,
+        "fetch_completed_weapon_leaderboard_fallback_data",
+        fetch_fallback,
+    )
+    monkeypatch.setattr(
+        leaderboard_mod, "fetch_live_weapon_leaderboard_data", fetch_live
+    )
+    monkeypatch.setattr(
+        leaderboard_mod, "Session", lambda: _CurrentSeasonSession()
+    )
+    monkeypatch.setattr(
+        leaderboard_mod, "fetch_current_season", lambda session: 15
+    )
+    monkeypatch.setattr(
+        leaderboard_mod, "get_all_alt_kits", lambda: {"1101": "40"}
+    )
+    monkeypatch.setattr(leaderboard_mod, "redis_conn", redis)
+
+    leaderboard_mod.fetch_weapon_leaderboard()
+
+    assert calls == {
+        "fallback": ({13, 14}, 15, {"1101": "40"}),
+        "live": (15, {"1101": "40"}),
+    }
+    payload = orjson.loads(
+        redis.values[leaderboard_mod.WEAPON_LEADERBOARD_PEAK_REDIS_KEY]
+    )
+    assert len(payload) == 4
+    collision = next(row for row in payload if row["player_id"] == "collision")
+    assert collision["max_x_power"] == 2600.0
+    assert {row["season_number"] for row in payload} == {13, 14, 15}
+    assert (
+        not pd.DataFrame(payload)
+        .assign(weapon_id_key=lambda frame: frame["weapon_id"].astype(str))
+        .duplicated(subset=leaderboard_mod.idx_columns + ["weapon_id_key"])
+        .any()
+    )


### PR DESCRIPTION
## Outcome

- Restore completed Top Weapons peak seasons that are missing from `xscraper.weapon_leaderboard`.
- Rebuild the latest completed season during archive handoff, then keep persisted archive rows authoritative on exact key collisions.
- Reuse the live-season alt-kit normalization, peak XP, game-count, and usage-percentage calculation for recovered rows.
- Add the rollover regression suite to the required Python 3.12/3.13 CI selection.

## Root cause

The persisted weapon archive currently contains raw seasons 1–13, while the live path only derives the current raw season 15. Fresh 2026/raw season 14 therefore disappeared from the snapshot after the season rollover even though its source observations are still retained.

## Safety and non-goals

- PostgreSQL remains read-only; recovered data flows through the existing Celery → Redis → SQLite snapshot pipeline.
- Persisted archive rows win if an archive publication overlaps a derived row.
- Official season-end results are unchanged. `season_results` is one-based relative to raw player/weapon seasons, and the authoritative Fresh result set (`season_results=15`) is not currently present; this PR does not manufacture it from peak history.
- React and Legacy Leaderboards are unchanged in this backend slice.

## Validation

- Python 3.12 and 3.13: 12/12 CI, rollover, and SQLite snapshot tests passed on each version.
- Exact pinned Redis 8.8/Celery compatibility check passed.
- `uv lock --check`, `uv pip check`, Black, isort, YAML parsing, and `git diff --check` passed.
- Pinned Node 24.15/npm 12.0.2: npm audit found 0 vulnerabilities; 32 suites / 105 tests passed; Vite production image built.
- FastAPI, Celery, and React CI-equivalent images built locally.
- Current GarzAICluster main: Prometheus validation, Helm lint, production lint, and projected v2.0.35 template passed with React held at v2.0.34.
- Production read-only parity: rebuilding season 13 matched all 41,237 archived rows exactly. The same algorithm produces 28,961 unique season-14 rows with no null/duplicate keys and candidate SHA-256 `96783fb75d7ae1d41644a65b41da6dc1944c6a1cc1c3378efff76a9919530e6e`.
- Full repository baseline: 189 passed; 28 unrelated pre-existing failures remain in Ripple fake-session tests and two archive/race routes outside this diff.

## Rollout

1. Merge after exact-head CI passes.
2. Publish and pin the v2.0.35 FastAPI/Celery images; keep React at v2.0.34.
3. Run the weapon leaderboard and SQLite snapshot refresh tasks.
4. Verify raw season 14 peak counts and values through the public API before the UI-label follow-up.
