### PR TITLE
Restore progressive player streaming and optimize history processing

### DIFF
--- a/src/celery_app/tasks/player_detail.py
+++ b/src/celery_app/tasks/player_detail.py
@@ -1,7 +1,9 @@
 import logging
 import math
+from collections.abc import Mapping
 from datetime import datetime, timezone
 from time import perf_counter
+from typing import Any, TypeVar
 
 import orjson
 from sqlalchemy import text
@@ -26,6 +28,8 @@ from shared_lib.queries.player_queries import (
 )
 
 logger = logging.getLogger(__name__)
+
+HistoryRow = TypeVar("HistoryRow", bound=Mapping[str, Any])
 
 PLAYER_CHUNK_VERSION = 2
 PLAYER_FETCH_LOCK_TTL_SECONDS = 300
@@ -272,11 +276,12 @@ def _fetch_player_data(player_id: str) -> list[dict]:
     base_query = text(PLAYER_DATA_QUERY)
     start = perf_counter()
     with Session() as session:
-        result = session.execute(
-            base_query, {"player_id": player_id}
-        ).fetchall()
+        result = (
+            session.execute(base_query, {"player_id": player_id})
+            .mappings()
+            .all()
+        )
 
-    result = [{**row._asdict()} for row in result]
     if metrics_enabled():
         DATA_PULL_DURATION.labels(
             task="player_detail.fetch_player_data"
@@ -285,15 +290,19 @@ def _fetch_player_data(player_id: str) -> list[dict]:
             len(result)
         )
         PLAYER_DETAIL_ROWS.labels(stage="history_raw").observe(len(result))
-    for player in result:
-        player["timestamp"] = player["timestamp"].isoformat()
 
     reduced = reduce_player_history_rows(result)
+    serialized = []
+    for row in reduced:
+        serialized_row = dict(row)
+        serialized_row["timestamp"] = serialized_row["timestamp"].isoformat()
+        serialized.append(serialized_row)
+
     if metrics_enabled():
         PLAYER_DETAIL_ROWS.labels(stage="history_reduced").observe(
-            len(reduced)
+            len(serialized)
         )
-    return reduced
+    return serialized
 
 
 def _fetch_season_data(player_id: str) -> list[dict]:
@@ -422,13 +431,15 @@ def _is_finite_number(value) -> bool:
     return isinstance(value, (int, float)) and math.isfinite(value)
 
 
-def _get_observed_day_key(timestamp: str | None) -> str | None:
-    if not isinstance(timestamp, str):
-        return None
-
-    try:
-        parsed = datetime.fromisoformat(timestamp)
-    except ValueError:
+def _get_observed_day_key(timestamp: str | datetime | None) -> str | None:
+    if isinstance(timestamp, datetime):
+        parsed = timestamp
+    elif isinstance(timestamp, str):
+        try:
+            parsed = datetime.fromisoformat(timestamp)
+        except ValueError:
+            return None
+    else:
         return None
 
     if parsed.tzinfo is None:
@@ -439,7 +450,9 @@ def _get_observed_day_key(timestamp: str | None) -> str | None:
     return parsed.date().isoformat()
 
 
-def reduce_player_history_rows(player_data: list[dict]) -> list[dict]:
+def reduce_player_history_rows(
+    player_data: list[HistoryRow],
+) -> list[HistoryRow]:
     """Keeps only chart-relevant history rows to shrink websocket payloads.
 
     The player page needs:
@@ -451,16 +464,20 @@ def reduce_player_history_rows(player_data: list[dict]) -> list[dict]:
     if not player_data:
         return []
 
-    previous_x_power_by_partition: dict[tuple[str | None, int | None], float] = {}
-    keep_keys: set[str] = set()
-    last_row_key_by_partition: dict[tuple[str | None, int | None], str] = {}
+    previous_x_power_by_partition: dict[
+        tuple[str | None, int | None], float
+    ] = {}
+    keep_keys: set[str | datetime] = set()
+    last_row_key_by_partition: dict[
+        tuple[str | None, int | None], str | datetime
+    ] = {}
     last_row_key_by_observed_day: dict[
-        tuple[str | None, int | None, str], str
+        tuple[str | None, int | None, str], str | datetime
     ] = {}
 
     for row in player_data:
         row_key = row.get("timestamp")
-        if not isinstance(row_key, str):
+        if not isinstance(row_key, (str, datetime)):
             continue
 
         partition_key = (row.get("mode"), row.get("season_number"))
@@ -494,7 +511,7 @@ def reduce_player_history_rows(player_data: list[dict]) -> list[dict]:
     reduced_rows = [
         row
         for row in player_data
-        if isinstance(row.get("timestamp"), str)
+        if isinstance(row.get("timestamp"), (str, datetime))
         and row["timestamp"] in keep_keys
     ]
 

--- a/src/react_app/src/components/player_components/playerDataUtils.js
+++ b/src/react_app/src/components/player_components/playerDataUtils.js
@@ -6,6 +6,9 @@ const aggregatedKeys = [
   "latest_data",
 ];
 
+const buildPlayerDetailWebsocketUrl = (baseUrl, playerId) =>
+  `${baseUrl}/ws/player/${playerId}?progressive=1&version=2`;
+
 const createPlayerDetailStreamState = () => ({
   chartData: null,
   analysisReady: false,
@@ -128,6 +131,7 @@ const reducePlayerDetailStreamState = (currentState, payload) => {
 };
 
 export {
+  buildPlayerDetailWebsocketUrl,
   createPlayerDetailStreamState,
   createEmptyPlayerDetailData,
   isLegacyPlayerDetailPayload,

--- a/src/react_app/src/components/player_components/playerDataUtils.test.js
+++ b/src/react_app/src/components/player_components/playerDataUtils.test.js
@@ -1,4 +1,5 @@
 import {
+  buildPlayerDetailWebsocketUrl,
   createPlayerDetailStreamState,
   createEmptyPlayerDetailData,
   isLegacyPlayerDetailPayload,
@@ -8,6 +9,14 @@ import {
 } from "./playerDataUtils";
 
 describe("playerDataUtils", () => {
+  it("opts player detail sockets into the progressive version 2 protocol", () => {
+    expect(
+      buildPlayerDetailWebsocketUrl("wss://api.splat.top", "player-123")
+    ).toBe(
+      "wss://api.splat.top/ws/player/player-123?progressive=1&version=2"
+    );
+  });
+
   it("creates an empty canonical player-detail payload", () => {
     expect(createEmptyPlayerDetailData()).toEqual({
       player_data: [],

--- a/src/react_app/src/components/player_detail.jsx
+++ b/src/react_app/src/components/player_detail.jsx
@@ -10,6 +10,7 @@ import {
   useWeaponAndTranslation,
 } from "./utils/weaponAndTranslation";
 import {
+  buildPlayerDetailWebsocketUrl,
   createPlayerDetailStreamState,
   reducePlayerDetailStreamState,
 } from "./player_components/playerDataUtils";
@@ -56,7 +57,10 @@ const PlayerDetailContent = () => {
       const apiUrl = getBaseApiUrl();
       const endpoint = `${apiUrl}/api/players/${player_id}`;
       const baseWebsocketUrl = getBaseWebsocketUrl();
-      const websocketEndpoint = `${baseWebsocketUrl}/ws/player/${player_id}`;
+      const websocketEndpoint = buildPlayerDetailWebsocketUrl(
+        baseWebsocketUrl,
+        player_id
+      );
 
       try {
         const playerData = await fetchJson(endpoint);

--- a/tests/celery/test_player_detail_progressive.py
+++ b/tests/celery/test_player_detail_progressive.py
@@ -1,6 +1,7 @@
 import importlib
 import os
 from collections import namedtuple
+from datetime import datetime, timezone
 
 import orjson
 
@@ -462,6 +463,84 @@ def test_reduce_player_history_rows_keeps_changes_updates_and_endpoints():
         "2024-12-05T00:00:00+00:00",
         "2024-12-06T00:00:00+00:00",
         "2024-12-07T00:00:00+00:00",
+    ]
+
+
+def test_fetch_player_history_serializes_only_reduced_rows(monkeypatch):
+    mod = importlib.import_module("celery_app.tasks.player_detail")
+    mod = importlib.reload(mod)
+    captured = {}
+
+    class DiscardedTimestamp(datetime):
+        def isoformat(self, *args, **kwargs):
+            raise AssertionError("discarded rows must not be serialized")
+
+    rows = [
+        {
+            "mode": "Rainmaker",
+            "region": False,
+            "season_number": 5,
+            "timestamp": datetime(2024, 12, 1, 0, tzinfo=timezone.utc),
+            "x_power": 2700.0,
+            "weapon_id": 10,
+            "rank": 30,
+            "updated": False,
+        },
+        {
+            "mode": "Rainmaker",
+            "region": False,
+            "season_number": 5,
+            "timestamp": DiscardedTimestamp(
+                2024, 12, 1, 1, tzinfo=timezone.utc
+            ),
+            "x_power": 2700.0,
+            "weapon_id": 10,
+            "rank": 30,
+            "updated": False,
+        },
+        {
+            "mode": "Rainmaker",
+            "region": False,
+            "season_number": 5,
+            "timestamp": datetime(2024, 12, 1, 2, tzinfo=timezone.utc),
+            "x_power": 2700.0,
+            "weapon_id": 10,
+            "rank": 30,
+            "updated": False,
+        },
+    ]
+
+    class FakeResult:
+        def mappings(self):
+            captured["used_mappings"] = True
+            return self
+
+        def all(self):
+            return rows
+
+    class FakeSession:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def execute(self, query, params):
+            captured["params"] = params
+            return FakeResult()
+
+    monkeypatch.setattr(mod, "Session", FakeSession)
+    monkeypatch.setattr(mod, "metrics_enabled", lambda: False)
+
+    result = mod._fetch_player_data("player-optimized")
+
+    assert captured == {
+        "used_mappings": True,
+        "params": {"player_id": "player-optimized"},
+    }
+    assert [row["timestamp"] for row in result] == [
+        "2024-12-01T00:00:00+00:00",
+        "2024-12-01T02:00:00+00:00",
     ]
 
 


### PR DESCRIPTION
## Outcome

- Restore the progressive player-detail WebSocket protocol (`progressive=1&version=2`).
- Reduce history rows before materializing dictionaries and serializing timestamps.
- Keep the existing 15-minute cache TTL unchanged.

## Root cause and impact

An unrelated frontend change removed the progressive query parameters even though the backend protocol remained supported. Cold player loads also converted every raw history row before discarding roughly 88% of them. This change restores progressive rendering and removes that avoidable CPU/object-allocation work.

## Validation

- Frontend: 32 Jest suites / 106 tests passed; `npm audit --audit-level=high` and production build passed with Node 24.15.0 / npm 12.0.2.
- Backend CI smoke matrix: 11 tests passed on both Python 3.12 and 3.13 using the frozen lockfile; package consistency checks passed.
- Focused player-detail suite: 9 tests passed.
- Production-data parity: 89,883 raw rows reduced to the same 10,458 output rows; processing decreased from 1.032s to 0.620s.
- Repository-wide test collection currently has 191 passing tests and 28 unrelated failures in untouched Ripple/archive route fixtures.

## Rollout and rollback

The main-branch release workflow will publish FastAPI, Celery, and React images, then open the immutable config-pin PR. Roll back by reverting the config pins to the previous component tags/digests.

## Non-goals

- No cache TTL, Redis, schema, credential, or authorization changes.
