### PR TITLE
Fix Sendou tournament match proxy

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -122,6 +122,7 @@ jobs:
       - name: Run startup and native WebSocket smoke tests
         run: >-
           uv run --frozen pytest -p no:cacheprovider
+          tests/routes/test_sendou_proxy.py
           tests/test_app_startup.py
           tests/test_player_websocket.py
           tests/celery/test_weapon_leaderboard.py

--- a/src/fast_api_app/routes/sendou_proxy.py
+++ b/src/fast_api_app/routes/sendou_proxy.py
@@ -24,7 +24,7 @@ REQUEST_TIMEOUT = 10.0
 
 # Route keys for different sendou.ink endpoints
 ROUTE_KEY_TOURNAMENT_MATCH = (
-    "features/tournament-bracket/routes/to.$id.matches.$mid"
+    "features/tournament-match/routes/to.$id.matches.$mid"
 )
 ROUTE_KEY_TOURNAMENT_TEAM = "features/tournament/routes/to.$id.teams.$tid"
 ROUTE_KEY_TOURNAMENT = "features/tournament/routes/to.$id"
@@ -56,8 +56,7 @@ def _decode_and_extract(
     route_data = decoder.get_route_data(route_key)
 
     if route_data is None:
-        # Return the full decoded data if route key not found
-        return decoder.decode()
+        raise ValueError(f"Route data not found: {route_key}")
 
     return route_data
 

--- a/src/react_app/package-lock.json
+++ b/src/react_app/package-lock.json
@@ -5527,9 +5527,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/tests/routes/test_sendou_proxy.py
+++ b/tests/routes/test_sendou_proxy.py
@@ -1,0 +1,52 @@
+import os
+
+import orjson
+import pytest
+
+os.environ.setdefault("DB_HOST", "localhost")
+os.environ.setdefault("DB_PORT", "5432")
+os.environ.setdefault("DB_USER", "user")
+os.environ.setdefault("DB_PASSWORD", "pass")
+os.environ.setdefault("DB_NAME", "db")
+os.environ.setdefault("RANKINGS_DB_NAME", "db")
+
+from fast_api_app.routes.sendou_proxy import (
+    ROUTE_KEY_TOURNAMENT_MATCH,
+    _decode_and_extract,
+)
+
+
+def _turbo_stream(route_key: str) -> bytes:
+    return orjson.dumps(
+        [
+            {"_1": 2},
+            route_key,
+            {"_3": 4},
+            "data",
+            {"_5": 6},
+            "match",
+            {"_7": 8},
+            "id",
+            134701,
+        ]
+    )
+
+
+def test_tournament_match_extracts_current_sendou_route_data():
+    result = _decode_and_extract(
+        _turbo_stream(ROUTE_KEY_TOURNAMENT_MATCH),
+        ROUTE_KEY_TOURNAMENT_MATCH,
+    )
+
+    assert ROUTE_KEY_TOURNAMENT_MATCH == (
+        "features/tournament-match/routes/to.$id.matches.$mid"
+    )
+    assert result == {"data": {"match": {"id": 134701}}}
+
+
+def test_missing_sendou_route_data_fails_instead_of_returning_route_tree():
+    with pytest.raises(ValueError, match="Route data not found"):
+        _decode_and_extract(
+            _turbo_stream("features/sendou/renamed-route"),
+            ROUTE_KEY_TOURNAMENT_MATCH,
+        )


### PR DESCRIPTION
## Summary
- update the renamed Sendou tournament-match turbo route key
- fail closed when an expected Sendou route key is missing instead of returning the entire route tree with HTTP 200
- add the regression coverage to the backend CI smoke set
- update locked nanoid 3.3.17 to 3.3.18 after the required npm audit gate surfaced GHSA-2v37-7h3g-55p8

## Verification
- Python 3.12: 13 backend smoke tests passed locally and in Actions
- Python 3.13: 13 backend smoke tests passed locally and in Actions
- Node 24.15.0 / npm 12.0.2: npm ci and high-severity audit passed with 0 vulnerabilities
- frontend: 32 suites / 106 tests passed; production build passed
- decoded the current live Sendou match payload for tournament 3898 / match 134701 and extracted only the expected data object

## CI parity
- local Docker daemon was unavailable; GitHub Actions performs all three image builds
- GitHub Actions supplies the Redis 8.8.0 compatibility service