### PR TITLE
Fix API endpoint index after FastAPI route refactor

### DIFF
--- a/src/fast_api_app/app.py
+++ b/src/fast_api_app/app.py
@@ -157,6 +157,7 @@ async def list_routes():
         "/api/search/",
     ]
     exclude_exact = ["/api", "/metrics"]
+    # FastAPI stores included routers behind route contexts, so flatten them.
     for route_context in iter_route_contexts(app.routes):
         path = route_context.path
         if (

--- a/src/fast_api_app/app.py
+++ b/src/fast_api_app/app.py
@@ -6,6 +6,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import HTMLResponse
+from fastapi.routing import iter_route_contexts
 from slowapi import _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
 from starlette.middleware.sessions import SessionMiddleware
@@ -156,15 +157,14 @@ async def list_routes():
         "/api/search/",
     ]
     exclude_exact = ["/api", "/metrics"]
-    for route in app.routes:
+    for route_context in iter_route_contexts(app.routes):
+        path = route_context.path
         if (
-            hasattr(route, "path")
-            and not any(
-                route.path.startswith(exclude) for exclude in exclude_paths
-            )
-            and route.path not in exclude_exact
+            path
+            and not any(path.startswith(exclude) for exclude in exclude_paths)
+            and path not in exclude_exact
         ):
-            html += f'<li><a href="{route.path}">{route.path}</a></li>'
+            html += f'<li><a href="{path}">{path}</a></li>'
     html += "</ul>"
     return HTMLResponse(content=html)
 

--- a/tests/test_app_startup.py
+++ b/tests/test_app_startup.py
@@ -4,6 +4,18 @@ import sys
 from fastapi.testclient import TestClient
 
 
+def test_api_index_lists_included_routes(client):
+    response = client.get("/api")
+
+    assert response.status_code == 200
+    assert '<a href="/api/weapon-info">' in response.text
+    assert '<a href="/api/ripple/public/metadata">' in response.text
+    assert '<a href="/api/players/{player_id}">' not in response.text
+    assert '<a href="/api/search/{query}">' not in response.text
+    assert '<a href="/metrics">' not in response.text
+    assert 'href=""' not in response.text
+
+
 def _reload_app_modules():
     for module_name in [
         "fast_api_app.sqlite_lookup_store",


### PR DESCRIPTION
## Summary

- Traverse included FastAPI routers with the supported `iter_route_contexts` API.
- Preserve the existing route exclusions and duplicate method links.
- Skip empty effective paths so WebSocket wrappers do not add a blank link.
- Add regression coverage to the backend smoke suite.

## Root cause

FastAPI 0.141 stores `include_router()` registrations behind route-context wrappers. Iterating raw `app.routes` therefore no longer exposes the included endpoint paths, leaving `/api` with an empty list.

## Verification

- Backend CI sequence with uv 0.12.2 and pinned Redis: 14 passed on Python 3.12.13.
- Backend CI sequence with uv 0.12.2 and pinned Redis: 14 passed on Python 3.13.14.
- Frontend CI sequence on Node 24.15.0 / npm 12.0.2: audit clean, 106 tests passed, production build passed.
- FastAPI, Celery, and React container builds passed.
- Black and `git diff --check` passed.
- Full backend suite has the same 28 unrelated failures as `main`; this branch adds one passing test (194 passed versus 193 on `main`).